### PR TITLE
feat: add CTW Signals evidence dashboards

### DIFF
--- a/ctw.studio/nav.js
+++ b/ctw.studio/nav.js
@@ -4,7 +4,7 @@
  * Usage: <script src="/nav.js" data-base="/" data-active="workshop"></script>
  *
  * data-base:   Path prefix to root (e.g. "/" from root, "../" from subdirs)
- * data-active:  Which nav link to highlight: "workshop", "work", "founder"
+ * data-active:  Which nav link to highlight: "signals", "workshop", "work", "founder"
  */
 (function () {
   const script = document.currentScript;
@@ -45,7 +45,8 @@
       background: linear-gradient(90deg, rgba(247, 181, 0, 0.9), transparent);
       transform: scaleX(0); transform-origin: left; transition: transform 0.25s ease;
     }
-    .nav-link:hover::after { transform: scaleX(1); }
+    .nav-link:hover::after,
+    .nav-link[aria-current="page"]::after { transform: scaleX(1); }
     /* Nav glitch effect */
     .glitch-sm { position: relative; display: inline-block; }
     .glitch-sm::before,
@@ -66,11 +67,16 @@
     .nav-label-mobile { display: none; }
     @media (max-width: 639px) {
       .studio-nav-inner { padding-left: 1rem !important; padding-right: 1rem !important; }
-      .studio-nav-links { gap: 0.875rem !important; }
+      .studio-nav-links { gap: 0.75rem !important; }
       .nav-label-desktop { display: none; }
       .nav-label-mobile { display: inline; }
       .glitch-sm.nav-compact::before,
       .glitch-sm.nav-compact::after { content: attr(data-mobile-text); }
+    }
+    @media (max-width: 480px) {
+      .studio-brand-label { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0; }
+      .studio-nav-links { gap: 0.7rem !important; }
+      .studio-contact { padding-left: 0.8rem !important; padding-right: 0.8rem !important; }
     }
     @keyframes glitch-sm-1 {
       0% { clip-path: inset(0 0 100% 0); }
@@ -97,6 +103,7 @@
 
   // Build nav links
   const links = [
+    { id: 'signals', href: base + 'signals/', label: 'Signals' },
     // Keep the workshop route visible on phones without the long label colliding with the brand + CTA.
     { id: 'workshop', href: base + 'workshop/', label: 'AI Workshop', mobileLabel: 'AI', glitch: true, classes: 'nav-compact' },
     { id: 'work', href: base + 'portfolio/', label: 'Work' },
@@ -105,6 +112,7 @@
 
   const linkHTML = links.map(l => {
     const isActive = active === l.id ? ' text-white' : '';
+    const current = active === l.id ? ' aria-current="page"' : '';
     const extraClasses = l.classes ? ' ' + l.classes : '';
     const labelHTML = l.mobileLabel
       ? `<span class="nav-label-desktop">${l.label}</span><span class="nav-label-mobile" aria-hidden="true">${l.mobileLabel}</span>`
@@ -112,9 +120,9 @@
     const aria = l.mobileLabel ? ` aria-label="${l.label}"` : '';
     if (l.glitch) {
       const mobileData = l.mobileLabel ? ` data-mobile-text="${l.mobileLabel}"` : '';
-      return `<a href="${l.href}" class="nav-link glitch-sm${isActive}${extraClasses}" data-text="${l.label}"${mobileData}${aria}>${labelHTML}</a>`;
+      return `<a href="${l.href}" class="nav-link glitch-sm${isActive}${extraClasses}" data-text="${l.label}"${mobileData}${aria}${current}>${labelHTML}</a>`;
     }
-    return `<a href="${l.href}" class="nav-link${isActive}${extraClasses}"${aria}>${labelHTML}</a>`;
+    return `<a href="${l.href}" class="nav-link${isActive}${extraClasses}"${aria}${current}>${labelHTML}</a>`;
   }).join('\n        ');
 
   const contactHref = base + '#contact';
@@ -129,11 +137,11 @@
     <div class="studio-nav-inner max-w-[1700px] mx-auto px-6 py-5 md:py-6 flex items-center justify-between relative">
       <a href="${base}" class="flex items-center gap-2.5">
         <img src="${base}favicon.png" alt="CTW Studio" class="w-9 h-9 md:w-10 md:h-10">
-        <span class="text-lg font-semibold tracking-tight">CTW<span class="text-amber-400">.</span>studio</span>
+        <span class="studio-brand-label text-lg font-semibold tracking-tight">CTW<span class="text-amber-400">.</span>studio</span>
       </a>
       <div class="studio-nav-links flex items-center gap-4 md:gap-8 text-sm md:text-base text-gray-300">
         ${linkHTML}
-        <a href="${contactHref}" class="border border-amber-400 text-amber-400 px-4 py-2 rounded-full font-medium hover:bg-amber-400 hover:text-black transition-colors">Contact</a>
+        <a href="${contactHref}" class="studio-contact border border-amber-400 text-amber-400 px-4 py-2 rounded-full font-medium hover:bg-amber-400 hover:text-black transition-colors">Contact</a>
       </div>
     </div>
   `;

--- a/ctw.studio/signals/README.md
+++ b/ctw.studio/signals/README.md
@@ -1,0 +1,69 @@
+# CTW Signals
+
+A lightweight, evidence-led dashboard inside `ctw.studio`. It treats important claims as inspectable briefings rather than a stream of context-free metrics.
+
+## Published briefs
+
+- **Brief 001 · AI & work** (`index.html`) — observed U.S. labor-market conditions, global AI exposure, early-career signals, employer expectations, adoption and productivity evidence.
+- **Brief 002 · Food, animals & the planet** (`food/index.html`) — animal slaughter, fish-count uncertainty, livestock emissions, product footprints, land, deforestation, water, oceans and health evidence.
+- **Queued · Housing & affordability** — compare prices with incomes, rents, mortgage costs, supply and household formation; do not equate price appreciation with affordability.
+
+## Files
+
+- `index.html` — AI/jobs editorial storyboard and accessible chart containers
+- `dashboard.js` — dependency-free AI/jobs rendering and interactions
+- `signals.css` — shared Signals visual system plus Brief 001 components
+- `data/ai-jobs.json` — curated AI/jobs evidence and baked FRED/BLS observations
+- `scripts/update_fred.py` — no-key refresh for FRED/BLS CSV series
+- `food/index.html` — food-system editorial storyboard
+- `food/food.js` — dependency-free food charts and source ledger
+- `food/food.css` — Brief 002 visual components
+- `data/food-system.json` — curated food-system evidence and baked observations
+- `scripts/update_food_data.py` — no-key refresh for FAO slaughter and product-footprint data via OWID
+- `tests/*.test.mjs` — source/data/markup integrity checks
+
+## Refreshing the data
+
+From `ctw.studio/`:
+
+```bash
+python3 signals/scripts/update_fred.py
+python3 signals/scripts/update_food_data.py
+node --test signals/tests/*.test.mjs
+```
+
+The scripts fetch and bake observations into JSON. Visitors do not call upstream APIs, so the public pages stay fast, deterministic and private.
+
+The AI/jobs updater downloads FRED CSV series sourced from BLS:
+
+- `JTSJOL` — total nonfarm job openings
+- `JTSHIL` — total nonfarm hires
+- `UNRATE` — unemployment rate
+
+The food-system updater downloads:
+
+- FAOSTAT slaughter observations republished in the OWID Grapher
+- Poore & Nemecek product-level supply-chain footprints republished in the OWID Grapher
+
+After either refresh:
+
+1. Review the diff for revisions, missing observations and definition changes.
+2. Confirm the source date and current-period labels.
+3. Run the full test suite.
+4. Inspect both pages at desktop and mobile widths before publishing.
+5. Commit the generated JSON with the source and script changes.
+
+## Editorial rules
+
+1. **Observations, experiments, exposure estimates and forecasts are different evidence types.** Label them.
+2. **Scope travels with every number.** Preserve geography, population, period and denominator.
+3. **Do not infer causation from timing alone.** AI-era labor movement is not automatically AI-caused.
+4. **Do not convert agriculture-wide shares into livestock shares.** Irrigation, crops, livestock and aquaculture overlap but are not interchangeable.
+5. **Do not combine official animal counts with modelled fish estimates.** Show the fish ranges and uncertainty separately.
+6. **Relative risk is not absolute risk.** Explain IARC evidence classes and effect-size units.
+7. **Scenarios are not forecasts.** A modelled plant-based land footprint says what a counterfactual system could require, not when behavior will change.
+8. **Prefer primary sources.** Use syntheses only when they expose the underlying study and definitions.
+
+## Adding the housing brief
+
+Give housing its own route and data file. Prefer official or established statistical series for house prices, disposable income, rents, mortgage rates/payments, completions, vacancies and household formation. Begin with a defined geography; a single national market must not be labeled as a global result.

--- a/ctw.studio/signals/README.md
+++ b/ctw.studio/signals/README.md
@@ -6,7 +6,8 @@ A lightweight, evidence-led dashboard inside `ctw.studio`. It treats important c
 
 - **Brief 001 · AI & work** (`index.html`) — observed U.S. labor-market conditions, global AI exposure, early-career signals, employer expectations, adoption and productivity evidence.
 - **Brief 002 · Food, animals & the planet** (`food/index.html`) — animal slaughter, fish-count uncertainty, livestock emissions, product footprints, land, deforestation, water, oceans and health evidence.
-- **Queued · Housing & affordability** — compare prices with incomes, rents, mortgage costs, supply and household formation; do not equate price appreciation with affordability.
+- **Brief 003 · Housing & affordability** (`housing/index.html`) — world housing adequacy, Dutch prices, rents, financing, tenure burden, supply and household formation, plus mechanism-led country comparisons.
+- **Signals atlas** (`roadmap/index.html`) — the shared five-question evidence contract, three geographic lenses and the ten-subject publication roadmap.
 
 ## Files
 
@@ -20,6 +21,11 @@ A lightweight, evidence-led dashboard inside `ctw.studio`. It treats important c
 - `food/food.css` — Brief 002 visual components
 - `data/food-system.json` — curated food-system evidence and baked observations
 - `scripts/update_food_data.py` — no-key refresh for FAO slaughter and product-footprint data via OWID
+- `housing/index.html` — Brief 003 housing storyboard using the shared five-question / three-lens contract
+- `housing/housing.js` and `housing/housing.css` — dependency-free housing charts, interactions and visual layer
+- `data/housing.json` — curated housing interpretation plus baked World Bank, OECD, Eurostat, CBS and ECB observations
+- `scripts/update_housing_data.py` — no-key refresh for eight official housing source series
+- `roadmap/index.html` — ten-subject Signals atlas and publication sequence
 - `tests/*.test.mjs` — source/data/markup integrity checks
 
 ## Refreshing the data
@@ -29,6 +35,7 @@ From `ctw.studio/`:
 ```bash
 python3 signals/scripts/update_fred.py
 python3 signals/scripts/update_food_data.py
+python3 signals/scripts/update_housing_data.py
 node --test signals/tests/*.test.mjs
 ```
 
@@ -45,12 +52,20 @@ The food-system updater downloads:
 - FAOSTAT slaughter observations republished in the OWID Grapher
 - Poore & Nemecek product-level supply-chain footprints republished in the OWID Grapher
 
-After either refresh:
+The housing updater downloads and reconciles:
+
+- World Bank / UN-Habitat urban slum share and matching world urban population
+- OECD analytical house-price, rent, price-to-income and price-to-rent indices
+- Eurostat housing-cost overburden and tenure shares
+- CBS existing-home prices, dwelling-stock changes and private households
+- ECB / DNB new-mortgage interest rates
+
+After any refresh:
 
 1. Review the diff for revisions, missing observations and definition changes.
 2. Confirm the source date and current-period labels.
 3. Run the full test suite.
-4. Inspect both pages at desktop and mobile widths before publishing.
+4. Inspect every affected page at desktop and mobile widths before publishing.
 5. Commit the generated JSON with the source and script changes.
 
 ## Editorial rules
@@ -62,8 +77,12 @@ After either refresh:
 5. **Do not combine official animal counts with modelled fish estimates.** Show the fish ranges and uncertainty separately.
 6. **Relative risk is not absolute risk.** Explain IARC evidence classes and effect-size units.
 7. **Scenarios are not forecasts.** A modelled plant-based land footprint says what a counterfactual system could require, not when behavior will change.
-8. **Prefer primary sources.** Use syntheses only when they expose the underlying study and definitions.
+8. **Housing prices are not housing affordability.** Keep prices, rents, income, financing and total burden distinct.
+9. **Country indices show change, not rank.** A 2015=100 comparison cannot establish absolute affordability.
+10. **National housing totals do not prove allocation.** Location, tenure, price, suitability, vacancy and accumulated backlog remain material.
+11. **Every new atlas brief answers the shared contract.** Show where we are, direction, distribution, competing explanations and what would change the conclusion, then label possibilities as hypotheses.
+12. **Prefer primary sources.** Use syntheses only when they expose the underlying study and definitions.
 
-## Adding the housing brief
+## Adding the next brief
 
-Give housing its own route and data file. Prefer official or established statistical series for house prices, disposable income, rents, mortgage rates/payments, completions, vacancies and household formation. Begin with a defined geography; a single national market must not be labeled as a global result.
+Follow the atlas contract in `roadmap/index.html`: one data file, a reproducible no-key updater where feasible, an inspectable source ledger, explicit world / Europe-Netherlands / selected-country scopes, and tests that fail on silent data gaps or denominator changes.

--- a/ctw.studio/signals/dashboard.js
+++ b/ctw.studio/signals/dashboard.js
@@ -1,0 +1,440 @@
+(() => {
+  'use strict';
+
+  const DATA_URL = 'data/ai-jobs.json';
+  const COLORS = {
+    observed: '#57d7ff',
+    observedFill: 'rgba(87, 215, 255, 0.12)',
+    exposure: '#f7b500',
+    high: '#ff6b5f',
+    experiment: '#a58bff',
+    forecast: '#53d38b',
+    grid: 'rgba(255,255,255,0.11)',
+    muted: '#8b8a84',
+    paper: '#f4f1e8'
+  };
+
+  let dashboardData = null;
+  let activeSeries = 'openings';
+
+  const $ = (selector, root = document) => root.querySelector(selector);
+  const $$ = (selector, root = document) => [...root.querySelectorAll(selector)];
+  const svgNS = 'http://www.w3.org/2000/svg';
+
+  function getSource(id) {
+    return dashboardData.sources.find((source) => source.id === id);
+  }
+
+  function safeHttpsUrl(value) {
+    try {
+      const url = new URL(value);
+      return url.protocol === 'https:' ? url.href : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function monthIndex(value) {
+    const [year, month] = value.slice(0, 7).split('-').map(Number);
+    return year * 12 + month - 1;
+  }
+
+  function formatMonth(value) {
+    const date = new Date(`${value.slice(0, 7)}-01T00:00:00Z`);
+    return new Intl.DateTimeFormat('en', { month: 'short', year: 'numeric', timeZone: 'UTC' }).format(date);
+  }
+
+  function formatValue(value, unit) {
+    if (unit === 'million') return `${Number(value).toFixed(value < 10 ? 2 : 1)}M`;
+    if (unit === 'percent') return `${Number(value).toFixed(1)}%`;
+    return String(value);
+  }
+
+  function signed(value, suffix = '%') {
+    const number = Number(value);
+    return `${number > 0 ? '+' : ''}${number.toFixed(1)}${suffix}`;
+  }
+
+  function setText(selector, text) {
+    const element = $(selector);
+    if (element) element.textContent = text;
+  }
+
+  function hydrateHeadline() {
+    const { headline, meta, evidence } = dashboardData;
+    setText('#data-as-of', `Official series refreshed ${formatMonth(meta.seriesUpdated)} · research reviewed ${formatMonth(meta.updated)}`);
+    setText('#openings-latest', formatValue(headline.openingsLatest.value, 'million'));
+    setText('#openings-latest-date', `U.S. · ${formatMonth(headline.openingsLatest.date)}`);
+    setText('#openings-change', signed(headline.openingsChangeSinceBaselinePct));
+    setText('#unemployment-latest', formatValue(headline.unemploymentLatest.value, 'percent'));
+    setText('#unemployment-latest-date', `U.S. · ${formatMonth(headline.unemploymentLatest.date)}`);
+    setText('#exposure-any', evidence.iloExposure.someExposurePct);
+    setText('#exposure-high', evidence.iloExposure.highestExposurePct);
+    setText('#early-career-decline', evidence.earlyCareer.relativeEmploymentDeclinePct);
+    setText('#adoption-rate', evidence.adoption.organizationsUsingAiPct);
+  }
+
+  function svgElement(name, attributes = {}, text = '') {
+    const element = document.createElementNS(svgNS, name);
+    Object.entries(attributes).forEach(([key, value]) => element.setAttribute(key, value));
+    if (text) element.textContent = text;
+    return element;
+  }
+
+  function renderMarketChart(seriesKey) {
+    activeSeries = seriesKey;
+    const config = dashboardData.series[seriesKey];
+    const observations = config.observations;
+    const svg = $('#market-chart');
+    const title = $('#market-chart-title');
+    const description = $('#market-chart-desc');
+    const sourceLink = $('#market-source');
+    const source = getSource(config.sourceId);
+    const tooltip = $('#chart-tooltip');
+
+    if (!svg || !observations.length) return;
+
+    title.textContent = `U.S. ${config.label.toLowerCase()}`;
+    const sourceUrl = safeHttpsUrl(source?.url);
+    if (sourceUrl) {
+      sourceLink.href = sourceUrl;
+      sourceLink.textContent = `${source.institution.replace('U.S. Bureau of Labor Statistics via ', '')} ↗`;
+    } else {
+      sourceLink.removeAttribute('href');
+      sourceLink.textContent = 'Source URL unavailable';
+    }
+
+    const latest = observations[observations.length - 1];
+    const baseline = observations.find((item) => item.date === dashboardData.headline.chatgptBaseline);
+    const difference = baseline
+      ? seriesKey === 'unemployment'
+        ? `${signed(latest.value - baseline.value, ' pp')} since Nov. 2022`
+        : `${signed(((latest.value - baseline.value) / baseline.value) * 100)} since Nov. 2022`
+      : '';
+    const unavailableNote = config.unavailable?.length
+      ? ` ${config.unavailable.map((item) => `${formatMonth(item.date)}: ${item.reason}`).join(' ')}`
+      : '';
+    description.textContent = `${config.definition} Latest: ${formatValue(latest.value, config.unit)} in ${formatMonth(latest.date)}; ${difference}. This series describes conditions, not AI causality.${unavailableNote}`;
+
+    const width = 780;
+    const height = 360;
+    const margin = { top: 28, right: 24, bottom: 54, left: 62 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
+    const values = observations.map((item) => item.value);
+    const rawMin = Math.min(...values);
+    const rawMax = Math.max(...values);
+    const padding = Math.max((rawMax - rawMin) * 0.16, config.unit === 'percent' ? 0.25 : 0.45);
+    const yMin = Math.max(0, rawMin - padding);
+    const yMax = rawMax + padding;
+    const firstMonth = monthIndex(observations[0].date);
+    const lastMonth = monthIndex(latest.date);
+    const monthSpan = Math.max(1, lastMonth - firstMonth);
+    const x = (observationDate) => margin.left + ((monthIndex(observationDate) - firstMonth) / monthSpan) * innerWidth;
+    const y = (value) => margin.top + ((yMax - value) / (yMax - yMin)) * innerHeight;
+
+    svg.replaceChildren();
+    svg.append(svgElement('title', {}, `${title.textContent}, January 2020 to ${formatMonth(latest.date)}`));
+    svg.append(svgElement('desc', {}, description.textContent));
+
+    const defs = svgElement('defs');
+    const gradient = svgElement('linearGradient', { id: 'market-area-gradient', x1: '0', y1: '0', x2: '0', y2: '1' });
+    gradient.append(
+      svgElement('stop', { offset: '0%', 'stop-color': COLORS.observed, 'stop-opacity': '0.25' }),
+      svgElement('stop', { offset: '100%', 'stop-color': COLORS.observed, 'stop-opacity': '0' })
+    );
+    defs.append(gradient);
+    svg.append(defs);
+
+    for (let tick = 0; tick <= 4; tick += 1) {
+      const value = yMin + ((yMax - yMin) * tick) / 4;
+      const position = y(value);
+      svg.append(svgElement('line', {
+        x1: margin.left,
+        x2: width - margin.right,
+        y1: position,
+        y2: position,
+        class: 'chart-grid-line'
+      }));
+      svg.append(svgElement('text', {
+        x: margin.left - 12,
+        y: position + 4,
+        'text-anchor': 'end',
+        class: 'chart-axis-label'
+      }, formatValue(value, config.unit)));
+    }
+
+    observations.forEach((item, index) => {
+      if (item.date.endsWith('-01-01')) {
+        svg.append(svgElement('text', {
+          x: x(item.date),
+          y: height - 20,
+          'text-anchor': 'middle',
+          class: 'chart-axis-label chart-year-label'
+        }, item.date.slice(0, 4)));
+      }
+    });
+
+    const launchObservation = observations.find((item) => item.date === '2022-11-01');
+    if (launchObservation) {
+      const launchX = x(launchObservation.date);
+      svg.append(svgElement('line', {
+        x1: launchX,
+        x2: launchX,
+        y1: margin.top,
+        y2: height - margin.bottom,
+        class: 'chart-annotation-line'
+      }));
+      svg.append(svgElement('text', {
+        x: launchX + 8,
+        y: margin.top + 14,
+        class: 'chart-annotation-label'
+      }, 'ChatGPT'));
+    }
+
+    const segments = observations.reduce((groups, item) => {
+      const current = groups[groups.length - 1];
+      const previous = current?.[current.length - 1];
+      if (!previous || monthIndex(item.date) - monthIndex(previous.date) === 1) {
+        if (current) current.push(item);
+        else groups.push([item]);
+      } else {
+        groups.push([item]);
+      }
+      return groups;
+    }, []);
+    segments.forEach((segment) => {
+      const points = segment.map((item) => `${x(item.date)},${y(item.value)}`);
+      const pathData = `M ${points.join(' L ')}`;
+      const areaData = `${pathData} L ${x(segment.at(-1).date)},${height - margin.bottom} L ${x(segment[0].date)},${height - margin.bottom} Z`;
+      svg.append(svgElement('path', { d: areaData, class: 'chart-area' }));
+      svg.append(svgElement('path', { d: pathData, class: 'chart-line' }));
+    });
+
+    const latestX = x(latest.date);
+    const latestY = y(latest.value);
+    svg.append(svgElement('circle', { cx: latestX, cy: latestY, r: 8, class: 'chart-latest-halo' }));
+    svg.append(svgElement('circle', { cx: latestX, cy: latestY, r: 4, class: 'chart-latest-dot' }));
+
+    const focusLine = svgElement('line', {
+      y1: margin.top,
+      y2: height - margin.bottom,
+      class: 'chart-focus-line',
+      hidden: 'true'
+    });
+    const focusDot = svgElement('circle', { r: 5, class: 'chart-focus-dot', hidden: 'true' });
+    svg.append(focusLine, focusDot);
+
+    let keyboardIndex = observations.length - 1;
+
+    function showPointByIndex(index) {
+      const bounds = svg.getBoundingClientRect();
+      const item = observations[index];
+      const pointX = x(item.date);
+      const pointY = y(item.value);
+      focusLine.setAttribute('x1', pointX);
+      focusLine.setAttribute('x2', pointX);
+      focusLine.removeAttribute('hidden');
+      focusDot.setAttribute('cx', pointX);
+      focusDot.setAttribute('cy', pointY);
+      focusDot.removeAttribute('hidden');
+      tooltip.hidden = false;
+      const tooltipValue = document.createElement('strong');
+      const tooltipDate = document.createElement('span');
+      tooltipValue.textContent = formatValue(item.value, config.unit);
+      tooltipDate.textContent = formatMonth(item.date);
+      tooltip.replaceChildren(tooltipValue, tooltipDate);
+      const left = Math.max(8, Math.min(bounds.width - 120, (pointX / width) * bounds.width - 44));
+      const top = Math.max(6, (pointY / height) * bounds.height - 68);
+      tooltip.style.transform = `translate(${left}px, ${top}px)`;
+    }
+
+    function hidePoint() {
+      tooltip.hidden = true;
+      focusLine.setAttribute('hidden', 'true');
+      focusDot.setAttribute('hidden', 'true');
+    }
+
+    function showPointFromPointer(clientX) {
+      const bounds = svg.getBoundingClientRect();
+      const viewX = ((clientX - bounds.left) / bounds.width) * width;
+      const targetMonth = firstMonth + ((viewX - margin.left) / innerWidth) * monthSpan;
+      const index = observations.reduce((closest, item, candidate) => (
+        Math.abs(monthIndex(item.date) - targetMonth) < Math.abs(monthIndex(observations[closest].date) - targetMonth)
+          ? candidate
+          : closest
+      ), 0);
+      keyboardIndex = index;
+      showPointByIndex(index);
+    }
+
+    svg.onpointermove = (event) => showPointFromPointer(event.clientX);
+    svg.onpointerleave = hidePoint;
+    svg.onfocus = () => showPointByIndex(keyboardIndex);
+    svg.onblur = hidePoint;
+    svg.onkeydown = (event) => {
+      if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+      event.preventDefault();
+      if (event.key === 'ArrowLeft') keyboardIndex = Math.max(0, keyboardIndex - 1);
+      if (event.key === 'ArrowRight') keyboardIndex = Math.min(observations.length - 1, keyboardIndex + 1);
+      if (event.key === 'Home') keyboardIndex = 0;
+      if (event.key === 'End') keyboardIndex = observations.length - 1;
+      showPointByIndex(keyboardIndex);
+    };
+
+    renderDataTable(config);
+    $$('.chart-switcher button').forEach((button) => {
+      button.setAttribute('aria-pressed', String(button.dataset.series === seriesKey));
+    });
+  }
+
+  function renderDataTable(config) {
+    const container = $('#market-data-table');
+    const table = document.createElement('table');
+    const caption = document.createElement('caption');
+    caption.textContent = `${config.label}, monthly observations`;
+    table.append(caption);
+    table.innerHTML += '<thead><tr><th scope="col">Month</th><th scope="col">Value</th></tr></thead>';
+    const body = document.createElement('tbody');
+    const rows = [
+      ...config.observations.map((item) => ({ ...item, available: true })),
+      ...(config.unavailable || []).map((item) => ({ ...item, available: false }))
+    ].sort((a, b) => b.date.localeCompare(a.date));
+    rows.forEach((item) => {
+      const row = document.createElement('tr');
+      const month = document.createElement('th');
+      const value = document.createElement('td');
+      month.scope = 'row';
+      month.textContent = formatMonth(item.date);
+      value.textContent = item.available ? formatValue(item.value, config.unit) : `Unavailable — ${item.reason}`;
+      row.append(month, value);
+      body.append(row);
+    });
+    table.append(body);
+    container.replaceChildren(table);
+  }
+
+  function renderExposure() {
+    const { someExposurePct, highestExposurePct } = dashboardData.evidence.iloExposure;
+    const otherExposure = someExposurePct - highestExposurePct;
+    const lowerExposure = 100 - someExposurePct;
+    const chart = $('#exposure-chart');
+    chart.innerHTML = '';
+    [
+      ['Highest exposure', highestExposurePct, 'exposure-chart__high'],
+      ['Other exposure', otherExposure, 'exposure-chart__some'],
+      ['Lower or no measured exposure', lowerExposure, 'exposure-chart__lower']
+    ].forEach(([label, value, className]) => {
+      const segment = document.createElement('span');
+      segment.className = className;
+      segment.style.width = `${value}%`;
+      segment.title = `${label}: ${Number(value).toFixed(1)}%`;
+      chart.append(segment);
+    });
+  }
+
+  function renderForecast() {
+    const forecast = dashboardData.evidence.wefForecast;
+    const rows = [
+      { label: 'Created', value: forecast.createdMillions, className: 'bar-row--created', sign: '+' },
+      { label: 'Displaced', value: forecast.displacedMillions, className: 'bar-row--displaced', sign: '−' },
+      { label: 'Net change', value: forecast.netMillions, className: 'bar-row--net', sign: '+' }
+    ];
+    const max = Math.max(...rows.map((row) => row.value));
+    const chart = $('#forecast-chart');
+    chart.replaceChildren(...rows.map((row) => {
+      const element = document.createElement('div');
+      element.className = `bar-row ${row.className}`;
+      element.innerHTML = `<span>${row.label}</span><div><i style="width:${(row.value / max) * 100}%"></i></div><strong>${row.sign}${row.value}M</strong>`;
+      return element;
+    }));
+  }
+
+  function renderProductivity() {
+    const productivity = dashboardData.evidence.productivity;
+    const rows = [
+      { label: 'Average agent', value: productivity.overallGainPct },
+      { label: 'Novice / lower-skilled', value: productivity.noviceGainPct }
+    ];
+    const max = 40;
+    const chart = $('#productivity-chart');
+    chart.replaceChildren(...rows.map((row) => {
+      const element = document.createElement('div');
+      element.className = 'productivity-row';
+      element.innerHTML = `<div><span>${row.label}</span><strong>+${row.value}%</strong></div><div class="productivity-track"><i style="width:${(row.value / max) * 100}%"></i></div>`;
+      return element;
+    }));
+  }
+
+  function renderSources() {
+    const list = $('#sources-list');
+    list.replaceChildren(...dashboardData.sources.map((source, index) => {
+      const item = document.createElement('li');
+      item.id = `source-${source.id}`;
+      const number = document.createElement('span');
+      number.className = 'source-number';
+      number.textContent = String(index + 1).padStart(2, '0');
+      const body = document.createElement('div');
+      const sourceUrl = safeHttpsUrl(source.url);
+      const link = document.createElement(sourceUrl ? 'a' : 'span');
+      if (sourceUrl) {
+        link.href = sourceUrl;
+        link.target = '_blank';
+        link.rel = 'noreferrer';
+      }
+      link.textContent = sourceUrl ? `${source.title} ↗` : `${source.title} — URL unavailable`;
+      const meta = document.createElement('p');
+      meta.className = 'source-meta';
+      meta.textContent = `${source.institution} · ${source.date}`;
+      const note = document.createElement('p');
+      note.className = 'source-note';
+      note.textContent = source.note;
+      body.append(link, meta, note);
+      item.append(number, body);
+      return item;
+    }));
+    setText('#source-count', `${dashboardData.sources.length} sources`);
+  }
+
+  function setupInteractions() {
+    $$('.chart-switcher button').forEach((button) => {
+      button.addEventListener('click', () => renderMarketChart(button.dataset.series));
+    });
+
+    if (!window.matchMedia('(prefers-reduced-motion: reduce)').matches && 'IntersectionObserver' in window) {
+      document.documentElement.classList.add('has-motion');
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('is-visible');
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.08, rootMargin: '0px 0px -8% 0px' });
+      $$('.reveal').forEach((element) => observer.observe(element));
+    }
+  }
+
+  async function init() {
+    try {
+      const response = await fetch(DATA_URL, { cache: 'no-cache' });
+      if (!response.ok) throw new Error(`Data request failed with ${response.status}`);
+      dashboardData = await response.json();
+      hydrateHeadline();
+      renderMarketChart(activeSeries);
+      renderExposure();
+      renderForecast();
+      renderProductivity();
+      renderSources();
+      setupInteractions();
+    } catch (error) {
+      console.error('Could not initialize CTW Signals dashboard', error);
+      setText('#data-as-of', 'Live series unavailable · reviewed evidence remains below');
+      const chart = $('#market-chart');
+      if (chart) chart.outerHTML = '<div class="chart-error">The live chart could not be loaded. Source links and interpretations remain available.</div>';
+      setupInteractions();
+    }
+  }
+
+  init();
+})();

--- a/ctw.studio/signals/data/ai-jobs.json
+++ b/ctw.studio/signals/data/ai-jobs.json
@@ -1,0 +1,1143 @@
+{
+  "meta": {
+    "topic": "AI and the job market",
+    "edition": 1,
+    "updated": "2026-07-22",
+    "seriesUpdated": "2026-07-23",
+    "geography": "Global evidence with live U.S. labour-market indicators",
+    "verdict": "Early transformation is visible; broad AI-driven mass displacement is not yet established.",
+    "method": "Separate observed outcomes, occupational exposure, controlled experiments, and forecasts. Never use one as a proxy for another."
+  },
+  "series": {
+    "openings": {
+      "fredId": "JTSJOL",
+      "label": "Job openings",
+      "shortLabel": "Openings",
+      "unit": "million",
+      "sourceId": "fred-jolts",
+      "definition": "Seasonally adjusted total nonfarm job openings in the United States.",
+      "observations": [
+        {
+          "date": "2020-01-01",
+          "value": 7.124
+        },
+        {
+          "date": "2020-02-01",
+          "value": 6.966
+        },
+        {
+          "date": "2020-03-01",
+          "value": 5.894
+        },
+        {
+          "date": "2020-04-01",
+          "value": 4.606
+        },
+        {
+          "date": "2020-05-01",
+          "value": 5.612
+        },
+        {
+          "date": "2020-06-01",
+          "value": 6.129
+        },
+        {
+          "date": "2020-07-01",
+          "value": 6.53
+        },
+        {
+          "date": "2020-08-01",
+          "value": 6.429
+        },
+        {
+          "date": "2020-09-01",
+          "value": 6.511
+        },
+        {
+          "date": "2020-10-01",
+          "value": 6.798
+        },
+        {
+          "date": "2020-11-01",
+          "value": 6.82
+        },
+        {
+          "date": "2020-12-01",
+          "value": 6.773
+        },
+        {
+          "date": "2021-01-01",
+          "value": 7.162
+        },
+        {
+          "date": "2021-02-01",
+          "value": 7.827
+        },
+        {
+          "date": "2021-03-01",
+          "value": 8.499
+        },
+        {
+          "date": "2021-04-01",
+          "value": 9.346
+        },
+        {
+          "date": "2021-05-01",
+          "value": 9.954
+        },
+        {
+          "date": "2021-06-01",
+          "value": 10.319
+        },
+        {
+          "date": "2021-07-01",
+          "value": 10.983
+        },
+        {
+          "date": "2021-08-01",
+          "value": 10.872
+        },
+        {
+          "date": "2021-09-01",
+          "value": 10.834
+        },
+        {
+          "date": "2021-10-01",
+          "value": 11.238
+        },
+        {
+          "date": "2021-11-01",
+          "value": 11.199
+        },
+        {
+          "date": "2021-12-01",
+          "value": 11.52
+        },
+        {
+          "date": "2022-01-01",
+          "value": 11.21
+        },
+        {
+          "date": "2022-02-01",
+          "value": 11.698
+        },
+        {
+          "date": "2022-03-01",
+          "value": 12.301
+        },
+        {
+          "date": "2022-04-01",
+          "value": 11.861
+        },
+        {
+          "date": "2022-05-01",
+          "value": 11.535
+        },
+        {
+          "date": "2022-06-01",
+          "value": 11.283
+        },
+        {
+          "date": "2022-07-01",
+          "value": 11.576
+        },
+        {
+          "date": "2022-08-01",
+          "value": 10.092
+        },
+        {
+          "date": "2022-09-01",
+          "value": 10.8
+        },
+        {
+          "date": "2022-10-01",
+          "value": 10.447
+        },
+        {
+          "date": "2022-11-01",
+          "value": 10.632
+        },
+        {
+          "date": "2022-12-01",
+          "value": 10.902
+        },
+        {
+          "date": "2023-01-01",
+          "value": 10.318
+        },
+        {
+          "date": "2023-02-01",
+          "value": 9.857
+        },
+        {
+          "date": "2023-03-01",
+          "value": 9.655
+        },
+        {
+          "date": "2023-04-01",
+          "value": 9.966
+        },
+        {
+          "date": "2023-05-01",
+          "value": 9.368
+        },
+        {
+          "date": "2023-06-01",
+          "value": 9.18
+        },
+        {
+          "date": "2023-07-01",
+          "value": 8.657
+        },
+        {
+          "date": "2023-08-01",
+          "value": 9.254
+        },
+        {
+          "date": "2023-09-01",
+          "value": 9.259
+        },
+        {
+          "date": "2023-10-01",
+          "value": 8.58
+        },
+        {
+          "date": "2023-11-01",
+          "value": 8.602
+        },
+        {
+          "date": "2023-12-01",
+          "value": 8.52
+        },
+        {
+          "date": "2024-01-01",
+          "value": 8.378
+        },
+        {
+          "date": "2024-02-01",
+          "value": 8.44
+        },
+        {
+          "date": "2024-03-01",
+          "value": 8.206
+        },
+        {
+          "date": "2024-04-01",
+          "value": 7.529
+        },
+        {
+          "date": "2024-05-01",
+          "value": 7.782
+        },
+        {
+          "date": "2024-06-01",
+          "value": 7.416
+        },
+        {
+          "date": "2024-07-01",
+          "value": 7.426
+        },
+        {
+          "date": "2024-08-01",
+          "value": 7.52
+        },
+        {
+          "date": "2024-09-01",
+          "value": 6.943
+        },
+        {
+          "date": "2024-10-01",
+          "value": 7.379
+        },
+        {
+          "date": "2024-11-01",
+          "value": 7.566
+        },
+        {
+          "date": "2024-12-01",
+          "value": 7.295
+        },
+        {
+          "date": "2025-01-01",
+          "value": 7.431
+        },
+        {
+          "date": "2025-02-01",
+          "value": 7.242
+        },
+        {
+          "date": "2025-03-01",
+          "value": 6.952
+        },
+        {
+          "date": "2025-04-01",
+          "value": 7.098
+        },
+        {
+          "date": "2025-05-01",
+          "value": 7.31
+        },
+        {
+          "date": "2025-06-01",
+          "value": 7.204
+        },
+        {
+          "date": "2025-07-01",
+          "value": 7.089
+        },
+        {
+          "date": "2025-08-01",
+          "value": 6.919
+        },
+        {
+          "date": "2025-09-01",
+          "value": 7.169
+        },
+        {
+          "date": "2025-10-01",
+          "value": 7.17
+        },
+        {
+          "date": "2025-11-01",
+          "value": 6.846
+        },
+        {
+          "date": "2025-12-01",
+          "value": 6.55
+        },
+        {
+          "date": "2026-01-01",
+          "value": 7.24
+        },
+        {
+          "date": "2026-02-01",
+          "value": 6.922
+        },
+        {
+          "date": "2026-03-01",
+          "value": 6.887
+        },
+        {
+          "date": "2026-04-01",
+          "value": 7.585
+        },
+        {
+          "date": "2026-05-01",
+          "value": 7.594
+        }
+      ],
+      "unavailable": [],
+      "latest": {
+        "date": "2026-05-01",
+        "value": 7.594
+      }
+    },
+    "hires": {
+      "fredId": "JTSHIL",
+      "label": "Hires",
+      "shortLabel": "Hires",
+      "unit": "million",
+      "sourceId": "fred-jolts",
+      "definition": "Seasonally adjusted total nonfarm hires in the United States.",
+      "observations": [
+        {
+          "date": "2020-01-01",
+          "value": 5.981
+        },
+        {
+          "date": "2020-02-01",
+          "value": 5.99
+        },
+        {
+          "date": "2020-03-01",
+          "value": 5.171
+        },
+        {
+          "date": "2020-04-01",
+          "value": 4.029
+        },
+        {
+          "date": "2020-05-01",
+          "value": 8.133
+        },
+        {
+          "date": "2020-06-01",
+          "value": 7.477
+        },
+        {
+          "date": "2020-07-01",
+          "value": 6.32
+        },
+        {
+          "date": "2020-08-01",
+          "value": 6.004
+        },
+        {
+          "date": "2020-09-01",
+          "value": 5.966
+        },
+        {
+          "date": "2020-10-01",
+          "value": 6.091
+        },
+        {
+          "date": "2020-11-01",
+          "value": 5.894
+        },
+        {
+          "date": "2020-12-01",
+          "value": 5.577
+        },
+        {
+          "date": "2021-01-01",
+          "value": 5.598
+        },
+        {
+          "date": "2021-02-01",
+          "value": 5.813
+        },
+        {
+          "date": "2021-03-01",
+          "value": 6.158
+        },
+        {
+          "date": "2021-04-01",
+          "value": 6.138
+        },
+        {
+          "date": "2021-05-01",
+          "value": 5.981
+        },
+        {
+          "date": "2021-06-01",
+          "value": 6.535
+        },
+        {
+          "date": "2021-07-01",
+          "value": 6.72
+        },
+        {
+          "date": "2021-08-01",
+          "value": 6.394
+        },
+        {
+          "date": "2021-09-01",
+          "value": 6.632
+        },
+        {
+          "date": "2021-10-01",
+          "value": 6.678
+        },
+        {
+          "date": "2021-11-01",
+          "value": 6.911
+        },
+        {
+          "date": "2021-12-01",
+          "value": 6.686
+        },
+        {
+          "date": "2022-01-01",
+          "value": 6.431
+        },
+        {
+          "date": "2022-02-01",
+          "value": 6.801
+        },
+        {
+          "date": "2022-03-01",
+          "value": 6.619
+        },
+        {
+          "date": "2022-04-01",
+          "value": 6.528
+        },
+        {
+          "date": "2022-05-01",
+          "value": 6.44
+        },
+        {
+          "date": "2022-06-01",
+          "value": 6.487
+        },
+        {
+          "date": "2022-07-01",
+          "value": 6.478
+        },
+        {
+          "date": "2022-08-01",
+          "value": 6.448
+        },
+        {
+          "date": "2022-09-01",
+          "value": 6.201
+        },
+        {
+          "date": "2022-10-01",
+          "value": 6.151
+        },
+        {
+          "date": "2022-11-01",
+          "value": 6.18
+        },
+        {
+          "date": "2022-12-01",
+          "value": 6.163
+        },
+        {
+          "date": "2023-01-01",
+          "value": 6.37
+        },
+        {
+          "date": "2023-02-01",
+          "value": 5.989
+        },
+        {
+          "date": "2023-03-01",
+          "value": 5.925
+        },
+        {
+          "date": "2023-04-01",
+          "value": 5.876
+        },
+        {
+          "date": "2023-05-01",
+          "value": 6.119
+        },
+        {
+          "date": "2023-06-01",
+          "value": 5.928
+        },
+        {
+          "date": "2023-07-01",
+          "value": 5.672
+        },
+        {
+          "date": "2023-08-01",
+          "value": 5.846
+        },
+        {
+          "date": "2023-09-01",
+          "value": 5.773
+        },
+        {
+          "date": "2023-10-01",
+          "value": 5.765
+        },
+        {
+          "date": "2023-11-01",
+          "value": 5.535
+        },
+        {
+          "date": "2023-12-01",
+          "value": 5.583
+        },
+        {
+          "date": "2024-01-01",
+          "value": 5.591
+        },
+        {
+          "date": "2024-02-01",
+          "value": 5.618
+        },
+        {
+          "date": "2024-03-01",
+          "value": 5.452
+        },
+        {
+          "date": "2024-04-01",
+          "value": 5.469
+        },
+        {
+          "date": "2024-05-01",
+          "value": 5.492
+        },
+        {
+          "date": "2024-06-01",
+          "value": 5.137
+        },
+        {
+          "date": "2024-07-01",
+          "value": 5.43
+        },
+        {
+          "date": "2024-08-01",
+          "value": 5.204
+        },
+        {
+          "date": "2024-09-01",
+          "value": 5.427
+        },
+        {
+          "date": "2024-10-01",
+          "value": 5.228
+        },
+        {
+          "date": "2024-11-01",
+          "value": 5.155
+        },
+        {
+          "date": "2024-12-01",
+          "value": 5.292
+        },
+        {
+          "date": "2025-01-01",
+          "value": 5.238
+        },
+        {
+          "date": "2025-02-01",
+          "value": 5.236
+        },
+        {
+          "date": "2025-03-01",
+          "value": 5.333
+        },
+        {
+          "date": "2025-04-01",
+          "value": 5.391
+        },
+        {
+          "date": "2025-05-01",
+          "value": 5.328
+        },
+        {
+          "date": "2025-06-01",
+          "value": 5.327
+        },
+        {
+          "date": "2025-07-01",
+          "value": 5.225
+        },
+        {
+          "date": "2025-08-01",
+          "value": 5.145
+        },
+        {
+          "date": "2025-09-01",
+          "value": 5.244
+        },
+        {
+          "date": "2025-10-01",
+          "value": 5.18
+        },
+        {
+          "date": "2025-11-01",
+          "value": 5.019
+        },
+        {
+          "date": "2025-12-01",
+          "value": 5.272
+        },
+        {
+          "date": "2026-01-01",
+          "value": 5.347
+        },
+        {
+          "date": "2026-02-01",
+          "value": 4.899
+        },
+        {
+          "date": "2026-03-01",
+          "value": 5.535
+        },
+        {
+          "date": "2026-04-01",
+          "value": 5.215
+        },
+        {
+          "date": "2026-05-01",
+          "value": 5.17
+        }
+      ],
+      "unavailable": [],
+      "latest": {
+        "date": "2026-05-01",
+        "value": 5.17
+      }
+    },
+    "unemployment": {
+      "fredId": "UNRATE",
+      "label": "Unemployment rate",
+      "shortLabel": "Unemployment",
+      "unit": "percent",
+      "sourceId": "fred-unrate",
+      "definition": "Seasonally adjusted U.S. civilian unemployment rate.",
+      "observations": [
+        {
+          "date": "2020-01-01",
+          "value": 3.6
+        },
+        {
+          "date": "2020-02-01",
+          "value": 3.5
+        },
+        {
+          "date": "2020-03-01",
+          "value": 4.4
+        },
+        {
+          "date": "2020-04-01",
+          "value": 14.8
+        },
+        {
+          "date": "2020-05-01",
+          "value": 13.2
+        },
+        {
+          "date": "2020-06-01",
+          "value": 11.0
+        },
+        {
+          "date": "2020-07-01",
+          "value": 10.2
+        },
+        {
+          "date": "2020-08-01",
+          "value": 8.4
+        },
+        {
+          "date": "2020-09-01",
+          "value": 7.8
+        },
+        {
+          "date": "2020-10-01",
+          "value": 6.9
+        },
+        {
+          "date": "2020-11-01",
+          "value": 6.7
+        },
+        {
+          "date": "2020-12-01",
+          "value": 6.7
+        },
+        {
+          "date": "2021-01-01",
+          "value": 6.4
+        },
+        {
+          "date": "2021-02-01",
+          "value": 6.2
+        },
+        {
+          "date": "2021-03-01",
+          "value": 6.1
+        },
+        {
+          "date": "2021-04-01",
+          "value": 6.1
+        },
+        {
+          "date": "2021-05-01",
+          "value": 5.8
+        },
+        {
+          "date": "2021-06-01",
+          "value": 5.9
+        },
+        {
+          "date": "2021-07-01",
+          "value": 5.4
+        },
+        {
+          "date": "2021-08-01",
+          "value": 5.1
+        },
+        {
+          "date": "2021-09-01",
+          "value": 4.7
+        },
+        {
+          "date": "2021-10-01",
+          "value": 4.5
+        },
+        {
+          "date": "2021-11-01",
+          "value": 4.1
+        },
+        {
+          "date": "2021-12-01",
+          "value": 3.9
+        },
+        {
+          "date": "2022-01-01",
+          "value": 4.0
+        },
+        {
+          "date": "2022-02-01",
+          "value": 3.9
+        },
+        {
+          "date": "2022-03-01",
+          "value": 3.7
+        },
+        {
+          "date": "2022-04-01",
+          "value": 3.7
+        },
+        {
+          "date": "2022-05-01",
+          "value": 3.6
+        },
+        {
+          "date": "2022-06-01",
+          "value": 3.6
+        },
+        {
+          "date": "2022-07-01",
+          "value": 3.5
+        },
+        {
+          "date": "2022-08-01",
+          "value": 3.6
+        },
+        {
+          "date": "2022-09-01",
+          "value": 3.5
+        },
+        {
+          "date": "2022-10-01",
+          "value": 3.6
+        },
+        {
+          "date": "2022-11-01",
+          "value": 3.6
+        },
+        {
+          "date": "2022-12-01",
+          "value": 3.5
+        },
+        {
+          "date": "2023-01-01",
+          "value": 3.5
+        },
+        {
+          "date": "2023-02-01",
+          "value": 3.6
+        },
+        {
+          "date": "2023-03-01",
+          "value": 3.5
+        },
+        {
+          "date": "2023-04-01",
+          "value": 3.4
+        },
+        {
+          "date": "2023-05-01",
+          "value": 3.6
+        },
+        {
+          "date": "2023-06-01",
+          "value": 3.6
+        },
+        {
+          "date": "2023-07-01",
+          "value": 3.5
+        },
+        {
+          "date": "2023-08-01",
+          "value": 3.7
+        },
+        {
+          "date": "2023-09-01",
+          "value": 3.7
+        },
+        {
+          "date": "2023-10-01",
+          "value": 3.9
+        },
+        {
+          "date": "2023-11-01",
+          "value": 3.7
+        },
+        {
+          "date": "2023-12-01",
+          "value": 3.8
+        },
+        {
+          "date": "2024-01-01",
+          "value": 3.7
+        },
+        {
+          "date": "2024-02-01",
+          "value": 3.9
+        },
+        {
+          "date": "2024-03-01",
+          "value": 3.9
+        },
+        {
+          "date": "2024-04-01",
+          "value": 3.9
+        },
+        {
+          "date": "2024-05-01",
+          "value": 3.9
+        },
+        {
+          "date": "2024-06-01",
+          "value": 4.1
+        },
+        {
+          "date": "2024-07-01",
+          "value": 4.2
+        },
+        {
+          "date": "2024-08-01",
+          "value": 4.2
+        },
+        {
+          "date": "2024-09-01",
+          "value": 4.1
+        },
+        {
+          "date": "2024-10-01",
+          "value": 4.1
+        },
+        {
+          "date": "2024-11-01",
+          "value": 4.2
+        },
+        {
+          "date": "2024-12-01",
+          "value": 4.1
+        },
+        {
+          "date": "2025-01-01",
+          "value": 4.0
+        },
+        {
+          "date": "2025-02-01",
+          "value": 4.2
+        },
+        {
+          "date": "2025-03-01",
+          "value": 4.2
+        },
+        {
+          "date": "2025-04-01",
+          "value": 4.2
+        },
+        {
+          "date": "2025-05-01",
+          "value": 4.3
+        },
+        {
+          "date": "2025-06-01",
+          "value": 4.1
+        },
+        {
+          "date": "2025-07-01",
+          "value": 4.3
+        },
+        {
+          "date": "2025-08-01",
+          "value": 4.3
+        },
+        {
+          "date": "2025-09-01",
+          "value": 4.4
+        },
+        {
+          "date": "2025-11-01",
+          "value": 4.5
+        },
+        {
+          "date": "2025-12-01",
+          "value": 4.4
+        },
+        {
+          "date": "2026-01-01",
+          "value": 4.3
+        },
+        {
+          "date": "2026-02-01",
+          "value": 4.4
+        },
+        {
+          "date": "2026-03-01",
+          "value": 4.3
+        },
+        {
+          "date": "2026-04-01",
+          "value": 4.3
+        },
+        {
+          "date": "2026-05-01",
+          "value": 4.3
+        },
+        {
+          "date": "2026-06-01",
+          "value": 4.2
+        }
+      ],
+      "unavailable": [
+        {
+          "date": "2025-10-01",
+          "reason": "Data unavailable due to the 2025 lapse in appropriations."
+        }
+      ],
+      "latest": {
+        "date": "2026-06-01",
+        "value": 4.2
+      }
+    }
+  },
+  "headline": {
+    "chatgptBaseline": "2022-11-01",
+    "openingsAtBaseline": {
+      "date": "2022-11-01",
+      "value": 10.632
+    },
+    "openingsLatest": {
+      "date": "2026-05-01",
+      "value": 7.594
+    },
+    "openingsChangeSinceBaselinePct": -28.6,
+    "preChatgptOpeningsPeak": {
+      "date": "2022-03-01",
+      "value": 12.301
+    },
+    "openingsChangeFromPreChatgptPeakPct": -38.3,
+    "hiresLatest": {
+      "date": "2026-05-01",
+      "value": 5.17
+    },
+    "unemploymentAtBaseline": {
+      "date": "2022-11-01",
+      "value": 3.6
+    },
+    "unemploymentLatest": {
+      "date": "2026-06-01",
+      "value": 4.2
+    },
+    "unemploymentChangeSinceBaselinePoints": 0.6
+  },
+  "evidence": {
+    "iloExposure": {
+      "someExposurePct": 25,
+      "someExposureLabel": "one in four",
+      "highestExposurePct": 3.3,
+      "womenHighestExposurePct": 4.7,
+      "menHighestExposurePct": 2.4,
+      "scope": "Global employment",
+      "period": "2025",
+      "kind": "Exposure estimate",
+      "interpretation": "Most exposed occupations still contain tasks requiring human input, so transformation is more likely than redundancy.",
+      "sourceId": "ilo-2025"
+    },
+    "earlyCareer": {
+      "relativeEmploymentDeclinePct": 16,
+      "ages": "22–25",
+      "scope": "U.S. workers in the most AI-exposed occupations",
+      "period": "Since widespread GenAI adoption; revised November 2025",
+      "kind": "Observed association · working paper",
+      "interpretation": "A concentrated warning signal, not an estimate of economy-wide job loss and not by itself definitive proof of causation.",
+      "sourceId": "stanford-canaries"
+    },
+    "macroLabour": {
+      "scope": "Whole U.S. labour market",
+      "period": "First 33 months after ChatGPT",
+      "kind": "Observed economy-wide comparison",
+      "finding": "No discernible broad disruption",
+      "interpretation": "Changes in the occupational mix were only about 1 percentage point faster than the comparable early-internet period and had started before ChatGPT.",
+      "sourceId": "yale-budget-lab"
+    },
+    "wefForecast": {
+      "createdMillions": 170,
+      "displacedMillions": 92,
+      "netMillions": 78,
+      "churnPct": 22,
+      "scope": "1.2 billion formal jobs across all structural macrotrends",
+      "period": "2025–2030",
+      "kind": "Employer-survey forecast",
+      "interpretation": "This is a scenario across technology, demographics, the green transition and other forces—not an AI-only prediction.",
+      "sourceId": "wef-2025"
+    },
+    "productivity": {
+      "overallGainPct": 14,
+      "noviceGainPct": 34,
+      "sampleSize": 5179,
+      "scope": "Customer-support agents at one company",
+      "period": "Study revised November 2023",
+      "kind": "Controlled workplace study",
+      "interpretation": "AI changed task performance and narrowed skill gaps in this setting; the study does not measure total jobs created or lost.",
+      "sourceId": "nber-31161"
+    },
+    "adoption": {
+      "organizationsUsingAiPct": 88,
+      "organizationsUsingGenAiPct": 70,
+      "period": "2025 survey data",
+      "kind": "Organizational survey",
+      "interpretation": "Use is widespread, but adoption is not the same thing as workforce reduction.",
+      "sourceId": "ai-index-2026"
+    }
+  },
+  "sources": [
+    {
+      "id": "fred-jolts",
+      "institution": "U.S. Bureau of Labor Statistics via FRED",
+      "title": "Job Openings and Labor Turnover Survey: total nonfarm job openings and hires",
+      "date": "Monthly; latest values shown in chart",
+      "url": "https://fred.stlouisfed.org/series/JTSJOL",
+      "note": "Observed U.S. labour-market indicators. They cannot identify whether a change was caused by AI. Values can be revised."
+    },
+    {
+      "id": "fred-unrate",
+      "institution": "U.S. Bureau of Labor Statistics via FRED",
+      "title": "Civilian unemployment rate",
+      "date": "Monthly; latest value shown in chart",
+      "url": "https://fred.stlouisfed.org/series/UNRATE",
+      "note": "Observed U.S. macro indicator; not an AI attribution series."
+    },
+    {
+      "id": "ilo-2025",
+      "institution": "International Labour Organization",
+      "title": "Generative AI and Jobs: A Refined Global Index of Occupational Exposure",
+      "date": "20 May 2025",
+      "url": "https://www.ilo.org/publications/generative-ai-and-jobs-refined-global-index-occupational-exposure",
+      "note": "Working Paper 140, DOI 10.54394/HETP0387. Exposure estimates are not counts of jobs lost."
+    },
+    {
+      "id": "yale-budget-lab",
+      "institution": "The Budget Lab at Yale",
+      "title": "Evaluating the Impact of AI on the Labor Market: Current State of Affairs",
+      "date": "1 October 2025",
+      "url": "https://budgetlab.yale.edu/research/evaluating-impact-ai-labor-market-current-state-affairs",
+      "note": "Economy-wide observational analysis; explicitly not predictive of future effects."
+    },
+    {
+      "id": "stanford-canaries",
+      "institution": "Stanford Digital Economy Lab",
+      "title": "Canaries in the Coal Mine? Six Facts about the Recent Employment Effects of Artificial Intelligence",
+      "date": "13 November 2025",
+      "url": "https://digitaleconomy.stanford.edu/publication/canaries-in-the-coal-mine-six-facts-about-the-recent-employment-effects-of-artificial-intelligence/",
+      "note": "Working paper using U.S. payroll-provider data. Strong subgroup signal, but not a peer-reviewed economy-wide causal estimate."
+    },
+    {
+      "id": "wef-2025",
+      "institution": "World Economic Forum",
+      "title": "Future of Jobs Report 2025",
+      "date": "January 2025",
+      "url": "https://reports.weforum.org/docs/WEF_Future_of_Jobs_Report_2025.pdf",
+      "note": "Forecast based on the Future of Jobs Survey 2024 and ILOSTAT; covers all structural macrotrends, not AI alone."
+    },
+    {
+      "id": "nber-31161",
+      "institution": "National Bureau of Economic Research",
+      "title": "Generative AI at Work, Working Paper 31161",
+      "date": "April 2023; revised November 2023",
+      "url": "https://www.nber.org/papers/w31161",
+      "note": "Workplace study of 5,179 customer-support agents; scope limits generalization."
+    },
+    {
+      "id": "ai-index-2026",
+      "institution": "Stanford Institute for Human-Centered AI",
+      "title": "2026 AI Index Report — Economy",
+      "date": "2026",
+      "url": "https://hai.stanford.edu/ai-index/2026-ai-index-report/economy",
+      "note": "Synthesis of investment, adoption, labour-market and productivity evidence; underlying sources vary by indicator."
+    }
+  ]
+}

--- a/ctw.studio/signals/data/food-system.json
+++ b/ctw.studio/signals/data/food-system.json
@@ -1,0 +1,316 @@
+{
+  "meta": {
+    "topic": "Food, animals & the planet",
+    "brief": "002",
+    "dataUpdated": "2026-07-22",
+    "editorialReview": "2026-07-22",
+    "updateMode": "Curated evidence; FAO slaughter and Poore–Nemecek product-footprint data refreshable by script",
+    "scope": "Global unless a card says otherwise"
+  },
+  "question": "What does eating animals cost — beyond the price tag?",
+  "verdict": {
+    "label": "The evidence is strong, but the boundaries matter",
+    "text": "Animal-sourced food is a major driver of land use, livestock emissions and animal deaths. Beef has an especially large climate and forest footprint. Agriculture also dominates freshwater withdrawals and nutrient pollution, but those system-wide shares should not be presented as livestock-only."
+  },
+  "slaughter": {
+    "year": 2024,
+    "daysInYear": 366,
+    "speciesIncluded": [
+      "Chicken",
+      "Duck",
+      "Pig",
+      "Sheep",
+      "Goat",
+      "Turkey",
+      "Cattle"
+    ],
+    "annualTracked": 86332055600,
+    "dailyTracked": 235879933,
+    "perMinuteTracked": 163806,
+    "species": [
+      {
+        "name": "Chicken",
+        "annual": 78533920000,
+        "daily": 214573552
+      },
+      {
+        "name": "Duck",
+        "annual": 4227882000,
+        "daily": 11551590
+      },
+      {
+        "name": "Pig",
+        "annual": 1493796992,
+        "daily": 4081413
+      },
+      {
+        "name": "Sheep",
+        "annual": 703861376,
+        "daily": 1923119
+      },
+      {
+        "name": "Goat",
+        "annual": 563722560,
+        "daily": 1540226
+      },
+      {
+        "name": "Turkey",
+        "annual": 504128000,
+        "daily": 1377399
+      },
+      {
+        "name": "Cattle",
+        "annual": 304744672,
+        "daily": 832636
+      }
+    ],
+    "sourceId": "owid-fao-slaughter",
+    "note": "Sum of seven major land-animal species available in the selected FAOSTAT/OWID series. It excludes fish, shellfish and unlisted land species."
+  },
+  "fishCounts": {
+    "farmed": {
+      "year": 2019,
+      "annualMidpointBillions": 124,
+      "annualLowBillions": 78,
+      "annualHighBillions": 171,
+      "dailyMidpointMillions": 339.7,
+      "dailyLowMillions": 213.7,
+      "dailyHighMillions": 468.5,
+      "sourceId": "mood-farmed-fish",
+      "note": "Peer-reviewed estimate based on FAO production tonnage and estimated harvest weights; not an official head count."
+    },
+    "wild": {
+      "year": 2019,
+      "annualLowBillions": 980,
+      "annualHighBillions": 1900,
+      "dailyLowBillions": 2.68,
+      "dailyHighBillions": 5.21,
+      "sourceId": "mood-wild-fish",
+      "note": "Peer-reviewed range for wild finfish caught in 2019. Biomass-to-individual conversion is uncertain and does not count all bycatch or unreported catch."
+    }
+  },
+  "climate": {
+    "livestockGtCO2e": 6.2,
+    "livestockShareAnthropogenicPct": 12,
+    "livestockShareAgrifoodPct": 40,
+    "baselineYear": 2015,
+    "sourceId": "fao-livestock-emissions",
+    "definition": "Livestock agrifood systems, including farm production and selected supply-chain processes such as feed-related land-use change, transport and inputs."
+  },
+  "land": {
+    "animalFoodShareAgriculturalLandPct": 83,
+    "animalFoodShareCaloriesPct": 18,
+    "animalFoodShareProteinPct": 37,
+    "currentAgriculturalLandBillionHa": 4.1,
+    "plantBasedScenarioBillionHa": 1,
+    "scenarioReductionPct": 75,
+    "sourceId": "poore-nemecek",
+    "note": "Land estimates come from the Poore–Nemecek global meta-analysis; the 4.1-to-1.0 billion hectare result is a modelled global plant-based scenario, not a forecast."
+  },
+  "forests": {
+    "beefShareTropicalDeforestationPct": 41,
+    "beefDeforestationMillionHaPerYear": 2.1,
+    "measurementPeriod": "2005–2013 average",
+    "soyFedToLivestockPct": 77,
+    "soyDirectHumanFoodPct": 7,
+    "sourceId": "owid-deforestation",
+    "note": "The beef estimate concerns tropical deforestation attributed to agricultural expansion in the cited study period; it is not 41% of all current global forest loss."
+  },
+  "water": {
+    "agricultureFreshwaterWithdrawalPct": 69,
+    "agricultureEutrophicationPct": 78,
+    "sourceIds": [
+      "fao-aquastat",
+      "owid-food-environment"
+    ],
+    "note": "Both are agriculture-wide shares. AQUASTAT's agriculture category includes irrigation, livestock and aquaculture; the sources do not assign the full global share to animal farming."
+  },
+  "oceans": {
+    "marineStocksSustainablePct": 62.3,
+    "marineStocksUnsustainablePct": 37.7,
+    "stockYear": 2021,
+    "captureMillionTonnes": 92.3,
+    "aquacultureAquaticAnimalsMillionTonnes": 94.4,
+    "productionYear": 2022,
+    "sourceId": "fao-sofia-2024",
+    "note": "Stock status is the unweighted share of marine stocks monitored by FAO. Production-weighted results are more favorable; the two measures answer different questions."
+  },
+  "health": {
+    "processedMeatIarcGroup": "Group 1",
+    "redMeatIarcGroup": "Group 2A",
+    "processedMeatPortionGrams": 50,
+    "colorectalRelativeRiskIncreasePct": 18,
+    "sourceId": "who-meat-cancer",
+    "veganDietGuidance": "A varied, balanced vegan diet can provide needed nutrients when it includes fortified foods and, where needed, supplements.",
+    "nutrientsToPlan": [
+      "vitamin B12",
+      "vitamin D",
+      "iodine",
+      "selenium",
+      "calcium",
+      "iron",
+      "omega-3"
+    ],
+    "guidanceSourceId": "nhs-vegan-diet",
+    "note": "IARC groups describe strength of causal evidence, not the size of risk. The 18% figure is a relative-risk estimate, not an 18 percentage-point absolute risk."
+  },
+  "productFootprints": [
+    {
+      "product": "Beef (beef herd)",
+      "year": 2018,
+      "kgCO2ePerKgFood": 99.48
+    },
+    {
+      "product": "Lamb & Mutton",
+      "year": 2018,
+      "kgCO2ePerKgFood": 39.72
+    },
+    {
+      "product": "Fish (farmed)",
+      "year": 2018,
+      "kgCO2ePerKgFood": 13.63
+    },
+    {
+      "product": "Pig Meat",
+      "year": 2018,
+      "kgCO2ePerKgFood": 12.31
+    },
+    {
+      "product": "Poultry Meat",
+      "year": 2018,
+      "kgCO2ePerKgFood": 9.87
+    },
+    {
+      "product": "Tofu",
+      "year": 2018,
+      "kgCO2ePerKgFood": 3.16
+    },
+    {
+      "product": "Peas",
+      "year": 2018,
+      "kgCO2ePerKgFood": 0.98
+    }
+  ],
+  "sources": [
+    {
+      "id": "owid-fao-slaughter",
+      "title": "Yearly number of animals slaughtered for meat",
+      "publisher": "Our World in Data, based on UN FAO data",
+      "url": "https://ourworldindata.org/grapher/animals-slaughtered-for-meat",
+      "publicationDate": "2025 data release",
+      "accessed": "2026-07-22",
+      "role": "Observed annual counts for seven major land-animal species",
+      "kind": "Administrative statistics"
+    },
+    {
+      "id": "mood-farmed-fish",
+      "title": "Estimating global numbers of farmed fishes killed for food annually from 1990 to 2019",
+      "publisher": "Animal Welfare / Cambridge University Press",
+      "url": "https://doi.org/10.1017/awf.2023.4",
+      "publicationDate": "2023",
+      "accessed": "2026-07-22",
+      "role": "Modelled individual counts for farmed finfish",
+      "kind": "Peer-reviewed estimate"
+    },
+    {
+      "id": "mood-wild-fish",
+      "title": "Estimating global numbers of fishes caught from the wild annually from 2000 to 2019",
+      "publisher": "Animal Welfare / Cambridge University Press",
+      "url": "https://doi.org/10.1017/awf.2024.7",
+      "publicationDate": "2024",
+      "accessed": "2026-07-22",
+      "role": "Modelled individual-count range for wild-caught finfish",
+      "kind": "Peer-reviewed estimate"
+    },
+    {
+      "id": "fao-livestock-emissions",
+      "title": "Pathways towards lower emissions: a global assessment of livestock agrifood systems",
+      "publisher": "Food and Agriculture Organization of the United Nations",
+      "url": "https://www.fao.org/newsroom/detail/new-fao-report-maps-pathways-towards-lower-livestock-emissions/en",
+      "publicationDate": "2023-12-08",
+      "accessed": "2026-07-22",
+      "role": "Global livestock-system emissions and scope definition",
+      "kind": "UN assessment"
+    },
+    {
+      "id": "poore-nemecek",
+      "title": "Reducing food's environmental impacts through producers and consumers",
+      "publisher": "Science",
+      "url": "https://pubmed.ncbi.nlm.nih.gov/29853680/",
+      "publicationDate": "2018-06-01",
+      "accessed": "2026-07-22",
+      "role": "Global meta-analysis of land use and product-level environmental impacts",
+      "kind": "Peer-reviewed meta-analysis"
+    },
+    {
+      "id": "owid-food-environment",
+      "title": "Environmental impacts of food production",
+      "publisher": "Our World in Data",
+      "url": "https://ourworldindata.org/environmental-impacts-of-food",
+      "publicationDate": "Living review",
+      "accessed": "2026-07-22",
+      "role": "Synthesis of land, calories, protein and agriculture-wide eutrophication",
+      "kind": "Research synthesis"
+    },
+    {
+      "id": "owid-deforestation",
+      "title": "Drivers of Deforestation",
+      "publisher": "Our World in Data, synthesizing Pendrill et al.",
+      "url": "https://ourworldindata.org/drivers-of-deforestation",
+      "publicationDate": "Updated 2024",
+      "accessed": "2026-07-22",
+      "role": "Tropical deforestation attribution and global soy end use",
+      "kind": "Research synthesis"
+    },
+    {
+      "id": "fao-aquastat",
+      "title": "AQUASTAT methodology: Water use",
+      "publisher": "Food and Agriculture Organization of the United Nations",
+      "url": "https://www.fao.org/aquastat/en/overview/methodology/water-use",
+      "publicationDate": "Living methodology",
+      "accessed": "2026-07-22",
+      "role": "Global freshwater-withdrawal shares and category definitions",
+      "kind": "UN methodology and statistics"
+    },
+    {
+      "id": "fao-sofia-2024",
+      "title": "The State of World Fisheries and Aquaculture 2024",
+      "publisher": "Food and Agriculture Organization of the United Nations",
+      "url": "https://www.fao.org/newsroom/detail/fao-report-global-fisheries-and-aquaculture-production-reaches-a-new-record-high/en",
+      "publicationDate": "2024-06-07",
+      "accessed": "2026-07-22",
+      "role": "Marine-stock status and fisheries/aquaculture production",
+      "kind": "UN assessment"
+    },
+    {
+      "id": "who-meat-cancer",
+      "title": "Cancer: Carcinogenicity of the consumption of red meat and processed meat",
+      "publisher": "World Health Organization / IARC",
+      "url": "https://www.who.int/news-room/questions-and-answers/item/cancer-carcinogenicity-of-the-consumption-of-red-meat-and-processed-meat",
+      "publicationDate": "2015-10-26",
+      "accessed": "2026-07-22",
+      "role": "Cancer evidence classifications and relative-risk estimate",
+      "kind": "Public-health evidence review"
+    },
+    {
+      "id": "nhs-vegan-diet",
+      "title": "The vegan diet",
+      "publisher": "UK National Health Service",
+      "url": "https://www.nhs.uk/live-well/eat-well/how-to-eat-a-balanced-diet/the-vegan-diet/",
+      "publicationDate": "Living guidance",
+      "accessed": "2026-07-22",
+      "role": "Nutritional adequacy and nutrients requiring planning",
+      "kind": "Public-health guidance"
+    },
+    {
+      "id": "who-amr",
+      "title": "Antimicrobial resistance",
+      "publisher": "World Health Organization",
+      "url": "https://www.who.int/news-room/fact-sheets/detail/antimicrobial-resistance",
+      "publicationDate": "2026-07-16",
+      "accessed": "2026-07-22",
+      "role": "Health burden and cross-sector drivers of antimicrobial resistance",
+      "kind": "Public-health fact sheet"
+    }
+  ]
+}

--- a/ctw.studio/signals/data/housing.json
+++ b/ctw.studio/signals/data/housing.json
@@ -1,0 +1,3002 @@
+{
+  "meta": {
+    "topic": "Housing & affordability",
+    "brief": "003",
+    "dataUpdated": "2026-07-23",
+    "editorialReview": "2026-07-23",
+    "question": "Is an ordinary life becoming more or less attainable?",
+    "scope": "World structure; Europe and the Netherlands in detail; selected-country comparisons",
+    "verdict": "Dutch house prices remain far ahead of incomes relative to 2015, financing remains much more expensive than in 2021, and the burden is concentrated among market-rate tenants. One recent year in which stock additions outpaced household formation cannot establish that the accumulated mismatch is resolved."
+  },
+  "framework": {
+    "questions": [
+      {
+        "id": "where-now",
+        "label": "Where are we now?"
+      },
+      {
+        "id": "direction",
+        "label": "What direction are we moving?"
+      },
+      {
+        "id": "distribution",
+        "label": "Who is benefiting or carrying the cost?"
+      },
+      {
+        "id": "explanations",
+        "label": "What are the competing explanations?"
+      },
+      {
+        "id": "change-evidence",
+        "label": "What evidence would change our current conclusion?"
+      }
+    ],
+    "lenses": [
+      {
+        "id": "world",
+        "label": "World",
+        "role": "Structural picture"
+      },
+      {
+        "id": "netherlands-europe",
+        "label": "Europe / Netherlands",
+        "role": "Lived political and economic context"
+      },
+      {
+        "id": "comparisons",
+        "label": "Selected countries",
+        "role": "Mechanism-led comparisons, not rankings"
+      }
+    ],
+    "possibilityQuestion": "What might this make possible?"
+  },
+  "world": {
+    "slumShare": {
+      "value": 23.2,
+      "rawValue": 23.2280234635748,
+      "unit": "% of urban population",
+      "period": "2022",
+      "sourceId": "world-bank-slums"
+    },
+    "urbanPopulation": {
+      "valueBillions": 4.56,
+      "valuePeople": 4559245664.0,
+      "period": "2022",
+      "sourceId": "world-bank-slums"
+    },
+    "estimatedPeople": {
+      "valueMillions": 1059,
+      "period": "2022",
+      "derived": true,
+      "note": "Derived from unrounded source values: the World Bank/UN-Habitat slum share and World Bank urban-population observation for the same year. It is not a direct census count.",
+      "sourceId": "world-bank-slums"
+    },
+    "limitations": "There is no timely, harmonized global affordability series covering prices, rents, incomes, mortgage access, tenure and informal housing. The world lens therefore shows housing adequacy, while OECD and Eurostat carry the affordability analysis."
+  },
+  "netherlands": {
+    "oecd": {
+      "housePrice": {
+        "measure": "HPI",
+        "label": "House-price index",
+        "base": "2015=100",
+        "frequency": "Quarterly, seasonally adjusted",
+        "observations": [
+          {
+            "period": "2010-Q1",
+            "value": 111.5
+          },
+          {
+            "period": "2010-Q2",
+            "value": 111.9
+          },
+          {
+            "period": "2010-Q3",
+            "value": 111.4
+          },
+          {
+            "period": "2010-Q4",
+            "value": 110.9
+          },
+          {
+            "period": "2011-Q1",
+            "value": 110.9
+          },
+          {
+            "period": "2011-Q2",
+            "value": 110.0
+          },
+          {
+            "period": "2011-Q3",
+            "value": 108.8
+          },
+          {
+            "period": "2011-Q4",
+            "value": 107.1
+          },
+          {
+            "period": "2012-Q1",
+            "value": 105.0
+          },
+          {
+            "period": "2012-Q2",
+            "value": 103.7
+          },
+          {
+            "period": "2012-Q3",
+            "value": 99.1
+          },
+          {
+            "period": "2012-Q4",
+            "value": 99.7
+          },
+          {
+            "period": "2013-Q1",
+            "value": 97.0
+          },
+          {
+            "period": "2013-Q2",
+            "value": 95.4
+          },
+          {
+            "period": "2013-Q3",
+            "value": 95.4
+          },
+          {
+            "period": "2013-Q4",
+            "value": 95.4
+          },
+          {
+            "period": "2014-Q1",
+            "value": 95.8
+          },
+          {
+            "period": "2014-Q2",
+            "value": 96.6
+          },
+          {
+            "period": "2014-Q3",
+            "value": 96.6
+          },
+          {
+            "period": "2014-Q4",
+            "value": 97.3
+          },
+          {
+            "period": "2015-Q1",
+            "value": 98.3
+          },
+          {
+            "period": "2015-Q2",
+            "value": 99.5
+          },
+          {
+            "period": "2015-Q3",
+            "value": 100.6
+          },
+          {
+            "period": "2015-Q4",
+            "value": 101.6
+          },
+          {
+            "period": "2016-Q1",
+            "value": 102.6
+          },
+          {
+            "period": "2016-Q2",
+            "value": 104.3
+          },
+          {
+            "period": "2016-Q3",
+            "value": 106.2
+          },
+          {
+            "period": "2016-Q4",
+            "value": 108.1
+          },
+          {
+            "period": "2017-Q1",
+            "value": 110.3
+          },
+          {
+            "period": "2017-Q2",
+            "value": 112.4
+          },
+          {
+            "period": "2017-Q3",
+            "value": 114.8
+          },
+          {
+            "period": "2017-Q4",
+            "value": 117.8
+          },
+          {
+            "period": "2018-Q1",
+            "value": 120.4
+          },
+          {
+            "period": "2018-Q2",
+            "value": 122.9
+          },
+          {
+            "period": "2018-Q3",
+            "value": 125.9
+          },
+          {
+            "period": "2018-Q4",
+            "value": 128.3
+          },
+          {
+            "period": "2019-Q1",
+            "value": 130.5
+          },
+          {
+            "period": "2019-Q2",
+            "value": 132.3
+          },
+          {
+            "period": "2019-Q3",
+            "value": 133.9
+          },
+          {
+            "period": "2019-Q4",
+            "value": 136.8
+          },
+          {
+            "period": "2020-Q1",
+            "value": 139.5
+          },
+          {
+            "period": "2020-Q2",
+            "value": 142.8
+          },
+          {
+            "period": "2020-Q3",
+            "value": 145.2
+          },
+          {
+            "period": "2020-Q4",
+            "value": 148.7
+          },
+          {
+            "period": "2021-Q1",
+            "value": 153.9
+          },
+          {
+            "period": "2021-Q2",
+            "value": 160.7
+          },
+          {
+            "period": "2021-Q3",
+            "value": 168.7
+          },
+          {
+            "period": "2021-Q4",
+            "value": 176.3
+          },
+          {
+            "period": "2022-Q1",
+            "value": 183.2
+          },
+          {
+            "period": "2022-Q2",
+            "value": 188.9
+          },
+          {
+            "period": "2022-Q3",
+            "value": 189.0
+          },
+          {
+            "period": "2022-Q4",
+            "value": 186.2
+          },
+          {
+            "period": "2023-Q1",
+            "value": 183.3
+          },
+          {
+            "period": "2023-Q2",
+            "value": 181.3
+          },
+          {
+            "period": "2023-Q3",
+            "value": 182.0
+          },
+          {
+            "period": "2023-Q4",
+            "value": 186.4
+          },
+          {
+            "period": "2024-Q1",
+            "value": 190.1
+          },
+          {
+            "period": "2024-Q2",
+            "value": 195.3
+          },
+          {
+            "period": "2024-Q3",
+            "value": 200.9
+          },
+          {
+            "period": "2024-Q4",
+            "value": 206.5
+          },
+          {
+            "period": "2025-Q1",
+            "value": 210.6
+          },
+          {
+            "period": "2025-Q2",
+            "value": 213.9
+          },
+          {
+            "period": "2025-Q3",
+            "value": 216.9
+          },
+          {
+            "period": "2025-Q4",
+            "value": 219.1
+          }
+        ],
+        "latest": {
+          "period": "2025-Q4",
+          "value": 219.1
+        },
+        "sourceId": "oecd-house-prices"
+      },
+      "rentPrice": {
+        "measure": "RPI",
+        "label": "Rent-price index",
+        "base": "2015=100",
+        "frequency": "Quarterly, seasonally adjusted",
+        "observations": [
+          {
+            "period": "2010-Q1",
+            "value": 85.4
+          },
+          {
+            "period": "2010-Q2",
+            "value": 85.8
+          },
+          {
+            "period": "2010-Q3",
+            "value": 85.8
+          },
+          {
+            "period": "2010-Q4",
+            "value": 86.3
+          },
+          {
+            "period": "2011-Q1",
+            "value": 86.8
+          },
+          {
+            "period": "2011-Q2",
+            "value": 87.3
+          },
+          {
+            "period": "2011-Q3",
+            "value": 87.3
+          },
+          {
+            "period": "2011-Q4",
+            "value": 87.7
+          },
+          {
+            "period": "2012-Q1",
+            "value": 88.4
+          },
+          {
+            "period": "2012-Q2",
+            "value": 88.9
+          },
+          {
+            "period": "2012-Q3",
+            "value": 89.7
+          },
+          {
+            "period": "2012-Q4",
+            "value": 90.2
+          },
+          {
+            "period": "2013-Q1",
+            "value": 90.9
+          },
+          {
+            "period": "2013-Q2",
+            "value": 91.5
+          },
+          {
+            "period": "2013-Q3",
+            "value": 93.7
+          },
+          {
+            "period": "2013-Q4",
+            "value": 94.4
+          },
+          {
+            "period": "2014-Q1",
+            "value": 95.1
+          },
+          {
+            "period": "2014-Q2",
+            "value": 95.8
+          },
+          {
+            "period": "2014-Q3",
+            "value": 97.8
+          },
+          {
+            "period": "2014-Q4",
+            "value": 98.5
+          },
+          {
+            "period": "2015-Q1",
+            "value": 99.2
+          },
+          {
+            "period": "2015-Q2",
+            "value": 99.8
+          },
+          {
+            "period": "2015-Q3",
+            "value": 100.2
+          },
+          {
+            "period": "2015-Q4",
+            "value": 100.7
+          },
+          {
+            "period": "2016-Q1",
+            "value": 101.4
+          },
+          {
+            "period": "2016-Q2",
+            "value": 102.0
+          },
+          {
+            "period": "2016-Q3",
+            "value": 102.2
+          },
+          {
+            "period": "2016-Q4",
+            "value": 102.8
+          },
+          {
+            "period": "2017-Q1",
+            "value": 103.4
+          },
+          {
+            "period": "2017-Q2",
+            "value": 104.0
+          },
+          {
+            "period": "2017-Q3",
+            "value": 103.8
+          },
+          {
+            "period": "2017-Q4",
+            "value": 104.4
+          },
+          {
+            "period": "2018-Q1",
+            "value": 105.0
+          },
+          {
+            "period": "2018-Q2",
+            "value": 105.7
+          },
+          {
+            "period": "2018-Q3",
+            "value": 106.2
+          },
+          {
+            "period": "2018-Q4",
+            "value": 106.9
+          },
+          {
+            "period": "2019-Q1",
+            "value": 107.5
+          },
+          {
+            "period": "2019-Q2",
+            "value": 108.2
+          },
+          {
+            "period": "2019-Q3",
+            "value": 108.9
+          },
+          {
+            "period": "2019-Q4",
+            "value": 109.6
+          },
+          {
+            "period": "2020-Q1",
+            "value": 110.2
+          },
+          {
+            "period": "2020-Q2",
+            "value": 111.0
+          },
+          {
+            "period": "2020-Q3",
+            "value": 112.0
+          },
+          {
+            "period": "2020-Q4",
+            "value": 112.8
+          },
+          {
+            "period": "2021-Q1",
+            "value": 113.4
+          },
+          {
+            "period": "2021-Q2",
+            "value": 114.2
+          },
+          {
+            "period": "2021-Q3",
+            "value": 112.9
+          },
+          {
+            "period": "2021-Q4",
+            "value": 113.6
+          },
+          {
+            "period": "2022-Q1",
+            "value": 114.3
+          },
+          {
+            "period": "2022-Q2",
+            "value": 115.2
+          },
+          {
+            "period": "2022-Q3",
+            "value": 116.2
+          },
+          {
+            "period": "2022-Q4",
+            "value": 116.9
+          },
+          {
+            "period": "2023-Q1",
+            "value": 117.8
+          },
+          {
+            "period": "2023-Q2",
+            "value": 118.8
+          },
+          {
+            "period": "2023-Q3",
+            "value": 118.4
+          },
+          {
+            "period": "2023-Q4",
+            "value": 119.1
+          },
+          {
+            "period": "2024-Q1",
+            "value": 120.2
+          },
+          {
+            "period": "2024-Q2",
+            "value": 121.4
+          },
+          {
+            "period": "2024-Q3",
+            "value": 124.7
+          },
+          {
+            "period": "2024-Q4",
+            "value": 125.5
+          },
+          {
+            "period": "2025-Q1",
+            "value": 126.7
+          },
+          {
+            "period": "2025-Q2",
+            "value": 128.1
+          },
+          {
+            "period": "2025-Q3",
+            "value": 130.6
+          },
+          {
+            "period": "2025-Q4",
+            "value": 131.6
+          },
+          {
+            "period": "2026-Q1",
+            "value": 132.9
+          },
+          {
+            "period": "2026-Q2",
+            "value": 134.5
+          }
+        ],
+        "latest": {
+          "period": "2026-Q2",
+          "value": 134.5
+        },
+        "sourceId": "oecd-house-prices"
+      },
+      "priceToIncome": {
+        "measure": "HPI_YDH",
+        "label": "Price-to-income index",
+        "base": "2015=100",
+        "frequency": "Quarterly, seasonally adjusted",
+        "observations": [
+          {
+            "period": "2010-Q1",
+            "value": 121.2
+          },
+          {
+            "period": "2010-Q2",
+            "value": 121.0
+          },
+          {
+            "period": "2010-Q3",
+            "value": 119.7
+          },
+          {
+            "period": "2010-Q4",
+            "value": 118.5
+          },
+          {
+            "period": "2011-Q1",
+            "value": 117.3
+          },
+          {
+            "period": "2011-Q2",
+            "value": 116.1
+          },
+          {
+            "period": "2011-Q3",
+            "value": 114.9
+          },
+          {
+            "period": "2011-Q4",
+            "value": 113.2
+          },
+          {
+            "period": "2012-Q1",
+            "value": 110.9
+          },
+          {
+            "period": "2012-Q2",
+            "value": 109.8
+          },
+          {
+            "period": "2012-Q3",
+            "value": 104.8
+          },
+          {
+            "period": "2012-Q4",
+            "value": 105.4
+          },
+          {
+            "period": "2013-Q1",
+            "value": 103.2
+          },
+          {
+            "period": "2013-Q2",
+            "value": 100.9
+          },
+          {
+            "period": "2013-Q3",
+            "value": 100.2
+          },
+          {
+            "period": "2013-Q4",
+            "value": 99.4
+          },
+          {
+            "period": "2014-Q1",
+            "value": 99.2
+          },
+          {
+            "period": "2014-Q2",
+            "value": 99.4
+          },
+          {
+            "period": "2014-Q3",
+            "value": 98.8
+          },
+          {
+            "period": "2014-Q4",
+            "value": 98.9
+          },
+          {
+            "period": "2015-Q1",
+            "value": 99.5
+          },
+          {
+            "period": "2015-Q2",
+            "value": 100.0
+          },
+          {
+            "period": "2015-Q3",
+            "value": 100.2
+          },
+          {
+            "period": "2015-Q4",
+            "value": 100.3
+          },
+          {
+            "period": "2016-Q1",
+            "value": 100.2
+          },
+          {
+            "period": "2016-Q2",
+            "value": 101.4
+          },
+          {
+            "period": "2016-Q3",
+            "value": 102.8
+          },
+          {
+            "period": "2016-Q4",
+            "value": 104.1
+          },
+          {
+            "period": "2017-Q1",
+            "value": 106.5
+          },
+          {
+            "period": "2017-Q2",
+            "value": 107.5
+          },
+          {
+            "period": "2017-Q3",
+            "value": 108.5
+          },
+          {
+            "period": "2017-Q4",
+            "value": 109.9
+          },
+          {
+            "period": "2018-Q1",
+            "value": 111.2
+          },
+          {
+            "period": "2018-Q2",
+            "value": 112.1
+          },
+          {
+            "period": "2018-Q3",
+            "value": 113.6
+          },
+          {
+            "period": "2018-Q4",
+            "value": 114.5
+          },
+          {
+            "period": "2019-Q1",
+            "value": 115.0
+          },
+          {
+            "period": "2019-Q2",
+            "value": 115.6
+          },
+          {
+            "period": "2019-Q3",
+            "value": 115.9
+          },
+          {
+            "period": "2019-Q4",
+            "value": 117.3
+          },
+          {
+            "period": "2020-Q1",
+            "value": 119.2
+          },
+          {
+            "period": "2020-Q2",
+            "value": 120.7
+          },
+          {
+            "period": "2020-Q3",
+            "value": 121.1
+          },
+          {
+            "period": "2020-Q4",
+            "value": 122.2
+          },
+          {
+            "period": "2021-Q1",
+            "value": 125.7
+          },
+          {
+            "period": "2021-Q2",
+            "value": 129.1
+          },
+          {
+            "period": "2021-Q3",
+            "value": 133.1
+          },
+          {
+            "period": "2021-Q4",
+            "value": 136.5
+          },
+          {
+            "period": "2022-Q1",
+            "value": 140.2
+          },
+          {
+            "period": "2022-Q2",
+            "value": 141.5
+          },
+          {
+            "period": "2022-Q3",
+            "value": 138.7
+          },
+          {
+            "period": "2022-Q4",
+            "value": 133.9
+          },
+          {
+            "period": "2023-Q1",
+            "value": 128.3
+          },
+          {
+            "period": "2023-Q2",
+            "value": 125.2
+          },
+          {
+            "period": "2023-Q3",
+            "value": 124.3
+          },
+          {
+            "period": "2023-Q4",
+            "value": 126.1
+          },
+          {
+            "period": "2024-Q1",
+            "value": 127.3
+          },
+          {
+            "period": "2024-Q2",
+            "value": 129.4
+          },
+          {
+            "period": "2024-Q3",
+            "value": 131.7
+          },
+          {
+            "period": "2024-Q4",
+            "value": 133.7
+          },
+          {
+            "period": "2025-Q1",
+            "value": 134.7
+          },
+          {
+            "period": "2025-Q2",
+            "value": 135.3
+          },
+          {
+            "period": "2025-Q3",
+            "value": 135.6
+          },
+          {
+            "period": "2025-Q4",
+            "value": 135.5
+          }
+        ],
+        "latest": {
+          "period": "2025-Q4",
+          "value": 135.5
+        },
+        "sourceId": "oecd-house-prices"
+      },
+      "priceToRent": {
+        "measure": "HPI_RPI",
+        "label": "Price-to-rent index",
+        "base": "2015=100",
+        "frequency": "Quarterly, seasonally adjusted",
+        "observations": [
+          {
+            "period": "2010-Q1",
+            "value": 130.6
+          },
+          {
+            "period": "2010-Q2",
+            "value": 130.4
+          },
+          {
+            "period": "2010-Q3",
+            "value": 129.8
+          },
+          {
+            "period": "2010-Q4",
+            "value": 128.6
+          },
+          {
+            "period": "2011-Q1",
+            "value": 127.9
+          },
+          {
+            "period": "2011-Q2",
+            "value": 126.0
+          },
+          {
+            "period": "2011-Q3",
+            "value": 124.7
+          },
+          {
+            "period": "2011-Q4",
+            "value": 122.1
+          },
+          {
+            "period": "2012-Q1",
+            "value": 118.8
+          },
+          {
+            "period": "2012-Q2",
+            "value": 116.7
+          },
+          {
+            "period": "2012-Q3",
+            "value": 110.5
+          },
+          {
+            "period": "2012-Q4",
+            "value": 110.6
+          },
+          {
+            "period": "2013-Q1",
+            "value": 106.7
+          },
+          {
+            "period": "2013-Q2",
+            "value": 104.2
+          },
+          {
+            "period": "2013-Q3",
+            "value": 101.8
+          },
+          {
+            "period": "2013-Q4",
+            "value": 101.0
+          },
+          {
+            "period": "2014-Q1",
+            "value": 100.7
+          },
+          {
+            "period": "2014-Q2",
+            "value": 100.8
+          },
+          {
+            "period": "2014-Q3",
+            "value": 98.8
+          },
+          {
+            "period": "2014-Q4",
+            "value": 98.8
+          },
+          {
+            "period": "2015-Q1",
+            "value": 99.0
+          },
+          {
+            "period": "2015-Q2",
+            "value": 99.7
+          },
+          {
+            "period": "2015-Q3",
+            "value": 100.4
+          },
+          {
+            "period": "2015-Q4",
+            "value": 100.8
+          },
+          {
+            "period": "2016-Q1",
+            "value": 101.2
+          },
+          {
+            "period": "2016-Q2",
+            "value": 102.3
+          },
+          {
+            "period": "2016-Q3",
+            "value": 104.0
+          },
+          {
+            "period": "2016-Q4",
+            "value": 105.1
+          },
+          {
+            "period": "2017-Q1",
+            "value": 106.7
+          },
+          {
+            "period": "2017-Q2",
+            "value": 108.0
+          },
+          {
+            "period": "2017-Q3",
+            "value": 110.6
+          },
+          {
+            "period": "2017-Q4",
+            "value": 112.8
+          },
+          {
+            "period": "2018-Q1",
+            "value": 114.6
+          },
+          {
+            "period": "2018-Q2",
+            "value": 116.3
+          },
+          {
+            "period": "2018-Q3",
+            "value": 118.6
+          },
+          {
+            "period": "2018-Q4",
+            "value": 120.1
+          },
+          {
+            "period": "2019-Q1",
+            "value": 121.4
+          },
+          {
+            "period": "2019-Q2",
+            "value": 122.3
+          },
+          {
+            "period": "2019-Q3",
+            "value": 123.0
+          },
+          {
+            "period": "2019-Q4",
+            "value": 124.8
+          },
+          {
+            "period": "2020-Q1",
+            "value": 126.6
+          },
+          {
+            "period": "2020-Q2",
+            "value": 128.7
+          },
+          {
+            "period": "2020-Q3",
+            "value": 129.6
+          },
+          {
+            "period": "2020-Q4",
+            "value": 131.8
+          },
+          {
+            "period": "2021-Q1",
+            "value": 135.7
+          },
+          {
+            "period": "2021-Q2",
+            "value": 140.7
+          },
+          {
+            "period": "2021-Q3",
+            "value": 149.4
+          },
+          {
+            "period": "2021-Q4",
+            "value": 155.1
+          },
+          {
+            "period": "2022-Q1",
+            "value": 160.2
+          },
+          {
+            "period": "2022-Q2",
+            "value": 164.0
+          },
+          {
+            "period": "2022-Q3",
+            "value": 162.7
+          },
+          {
+            "period": "2022-Q4",
+            "value": 159.2
+          },
+          {
+            "period": "2023-Q1",
+            "value": 155.7
+          },
+          {
+            "period": "2023-Q2",
+            "value": 152.7
+          },
+          {
+            "period": "2023-Q3",
+            "value": 153.7
+          },
+          {
+            "period": "2023-Q4",
+            "value": 156.5
+          },
+          {
+            "period": "2024-Q1",
+            "value": 158.2
+          },
+          {
+            "period": "2024-Q2",
+            "value": 160.9
+          },
+          {
+            "period": "2024-Q3",
+            "value": 161.2
+          },
+          {
+            "period": "2024-Q4",
+            "value": 164.5
+          },
+          {
+            "period": "2025-Q1",
+            "value": 166.1
+          },
+          {
+            "period": "2025-Q2",
+            "value": 167.0
+          },
+          {
+            "period": "2025-Q3",
+            "value": 166.1
+          },
+          {
+            "period": "2025-Q4",
+            "value": 166.5
+          }
+        ],
+        "latest": {
+          "period": "2025-Q4",
+          "value": 166.5
+        },
+        "sourceId": "oecd-house-prices"
+      }
+    },
+    "cbs": {
+      "existingHomes": {
+        "observations": [
+          {
+            "period": "2015-01",
+            "priceIndex2020": 68.3,
+            "yearOnYearPct": 2.5,
+            "soldHomes": 9437,
+            "averagePurchasePriceEur": 222800
+          },
+          {
+            "period": "2015-02",
+            "priceIndex2020": 68.5,
+            "yearOnYearPct": 2.8,
+            "soldHomes": 11697,
+            "averagePurchasePriceEur": 216678
+          },
+          {
+            "period": "2015-03",
+            "priceIndex2020": 68.6,
+            "yearOnYearPct": 3.2,
+            "soldHomes": 13393,
+            "averagePurchasePriceEur": 225024
+          },
+          {
+            "period": "2015-04",
+            "priceIndex2020": 68.8,
+            "yearOnYearPct": 2.7,
+            "soldHomes": 12748,
+            "averagePurchasePriceEur": 224376
+          },
+          {
+            "period": "2015-05",
+            "priceIndex2020": 68.9,
+            "yearOnYearPct": 3.0,
+            "soldHomes": 12827,
+            "averagePurchasePriceEur": 228032
+          },
+          {
+            "period": "2015-06",
+            "priceIndex2020": 69.3,
+            "yearOnYearPct": 3.1,
+            "soldHomes": 15147,
+            "averagePurchasePriceEur": 229381
+          },
+          {
+            "period": "2015-07",
+            "priceIndex2020": 69.9,
+            "yearOnYearPct": 3.3,
+            "soldHomes": 18422,
+            "averagePurchasePriceEur": 232562
+          },
+          {
+            "period": "2015-08",
+            "priceIndex2020": 69.9,
+            "yearOnYearPct": 3.1,
+            "soldHomes": 15863,
+            "averagePurchasePriceEur": 233485
+          },
+          {
+            "period": "2015-09",
+            "priceIndex2020": 70.4,
+            "yearOnYearPct": 4.0,
+            "soldHomes": 16324,
+            "averagePurchasePriceEur": 233956
+          },
+          {
+            "period": "2015-10",
+            "priceIndex2020": 70.6,
+            "yearOnYearPct": 3.9,
+            "soldHomes": 16324,
+            "averagePurchasePriceEur": 237796
+          },
+          {
+            "period": "2015-11",
+            "priceIndex2020": 70.7,
+            "yearOnYearPct": 4.3,
+            "soldHomes": 14545,
+            "averagePurchasePriceEur": 234610
+          },
+          {
+            "period": "2015-12",
+            "priceIndex2020": 70.5,
+            "yearOnYearPct": 3.6,
+            "soldHomes": 21566,
+            "averagePurchasePriceEur": 233242
+          },
+          {
+            "period": "2016-01",
+            "priceIndex2020": 71.2,
+            "yearOnYearPct": 4.4,
+            "soldHomes": 11907,
+            "averagePurchasePriceEur": 238934
+          },
+          {
+            "period": "2016-02",
+            "priceIndex2020": 71.3,
+            "yearOnYearPct": 4.2,
+            "soldHomes": 14866,
+            "averagePurchasePriceEur": 234830
+          },
+          {
+            "period": "2016-03",
+            "priceIndex2020": 71.8,
+            "yearOnYearPct": 4.7,
+            "soldHomes": 16124,
+            "averagePurchasePriceEur": 235799
+          },
+          {
+            "period": "2016-04",
+            "priceIndex2020": 72.0,
+            "yearOnYearPct": 4.7,
+            "soldHomes": 16387,
+            "averagePurchasePriceEur": 239522
+          },
+          {
+            "period": "2016-05",
+            "priceIndex2020": 72.4,
+            "yearOnYearPct": 5.0,
+            "soldHomes": 16066,
+            "averagePurchasePriceEur": 236730
+          },
+          {
+            "period": "2016-06",
+            "priceIndex2020": 72.9,
+            "yearOnYearPct": 5.1,
+            "soldHomes": 17862,
+            "averagePurchasePriceEur": 242089
+          },
+          {
+            "period": "2016-07",
+            "priceIndex2020": 73.6,
+            "yearOnYearPct": 5.3,
+            "soldHomes": 19723,
+            "averagePurchasePriceEur": 245980
+          },
+          {
+            "period": "2016-08",
+            "priceIndex2020": 74.3,
+            "yearOnYearPct": 6.3,
+            "soldHomes": 19975,
+            "averagePurchasePriceEur": 249054
+          },
+          {
+            "period": "2016-09",
+            "priceIndex2020": 74.9,
+            "yearOnYearPct": 6.5,
+            "soldHomes": 21009,
+            "averagePurchasePriceEur": 253498
+          },
+          {
+            "period": "2016-10",
+            "priceIndex2020": 74.9,
+            "yearOnYearPct": 6.1,
+            "soldHomes": 17339,
+            "averagePurchasePriceEur": 247673
+          },
+          {
+            "period": "2016-11",
+            "priceIndex2020": 75.2,
+            "yearOnYearPct": 6.4,
+            "soldHomes": 18255,
+            "averagePurchasePriceEur": 246819
+          },
+          {
+            "period": "2016-12",
+            "priceIndex2020": 75.6,
+            "yearOnYearPct": 7.2,
+            "soldHomes": 25280,
+            "averagePurchasePriceEur": 246511
+          },
+          {
+            "period": "2017-01",
+            "priceIndex2020": 76.3,
+            "yearOnYearPct": 7.1,
+            "soldHomes": 16555,
+            "averagePurchasePriceEur": 258467
+          },
+          {
+            "period": "2017-02",
+            "priceIndex2020": 76.5,
+            "yearOnYearPct": 7.2,
+            "soldHomes": 17708,
+            "averagePurchasePriceEur": 253388
+          },
+          {
+            "period": "2017-03",
+            "priceIndex2020": 77.4,
+            "yearOnYearPct": 7.8,
+            "soldHomes": 21648,
+            "averagePurchasePriceEur": 258838
+          },
+          {
+            "period": "2017-04",
+            "priceIndex2020": 77.6,
+            "yearOnYearPct": 7.9,
+            "soldHomes": 16694,
+            "averagePurchasePriceEur": 256800
+          },
+          {
+            "period": "2017-05",
+            "priceIndex2020": 78.3,
+            "yearOnYearPct": 8.1,
+            "soldHomes": 19990,
+            "averagePurchasePriceEur": 259615
+          },
+          {
+            "period": "2017-06",
+            "priceIndex2020": 79.0,
+            "yearOnYearPct": 8.4,
+            "soldHomes": 21686,
+            "averagePurchasePriceEur": 264362
+          },
+          {
+            "period": "2017-07",
+            "priceIndex2020": 79.7,
+            "yearOnYearPct": 8.3,
+            "soldHomes": 19979,
+            "averagePurchasePriceEur": 264007
+          },
+          {
+            "period": "2017-08",
+            "priceIndex2020": 80.5,
+            "yearOnYearPct": 8.3,
+            "soldHomes": 20780,
+            "averagePurchasePriceEur": 268452
+          },
+          {
+            "period": "2017-09",
+            "priceIndex2020": 80.8,
+            "yearOnYearPct": 7.9,
+            "soldHomes": 20632,
+            "averagePurchasePriceEur": 269817
+          },
+          {
+            "period": "2017-10",
+            "priceIndex2020": 81.4,
+            "yearOnYearPct": 8.7,
+            "soldHomes": 20143,
+            "averagePurchasePriceEur": 269083
+          },
+          {
+            "period": "2017-11",
+            "priceIndex2020": 81.8,
+            "yearOnYearPct": 8.8,
+            "soldHomes": 19647,
+            "averagePurchasePriceEur": 267868
+          },
+          {
+            "period": "2017-12",
+            "priceIndex2020": 82.1,
+            "yearOnYearPct": 8.7,
+            "soldHomes": 26398,
+            "averagePurchasePriceEur": 265122
+          },
+          {
+            "period": "2018-01",
+            "priceIndex2020": 83.1,
+            "yearOnYearPct": 9.0,
+            "soldHomes": 16035,
+            "averagePurchasePriceEur": 276906
+          },
+          {
+            "period": "2018-02",
+            "priceIndex2020": 84.0,
+            "yearOnYearPct": 9.8,
+            "soldHomes": 16094,
+            "averagePurchasePriceEur": 275201
+          },
+          {
+            "period": "2018-03",
+            "priceIndex2020": 84.3,
+            "yearOnYearPct": 8.9,
+            "soldHomes": 19976,
+            "averagePurchasePriceEur": 281548
+          },
+          {
+            "period": "2018-04",
+            "priceIndex2020": 84.7,
+            "yearOnYearPct": 9.1,
+            "soldHomes": 16267,
+            "averagePurchasePriceEur": 280027
+          },
+          {
+            "period": "2018-05",
+            "priceIndex2020": 85.5,
+            "yearOnYearPct": 9.2,
+            "soldHomes": 18237,
+            "averagePurchasePriceEur": 283945
+          },
+          {
+            "period": "2018-06",
+            "priceIndex2020": 86.2,
+            "yearOnYearPct": 9.2,
+            "soldHomes": 18426,
+            "averagePurchasePriceEur": 289399
+          },
+          {
+            "period": "2018-07",
+            "priceIndex2020": 87.0,
+            "yearOnYearPct": 9.1,
+            "soldHomes": 19580,
+            "averagePurchasePriceEur": 290731
+          },
+          {
+            "period": "2018-08",
+            "priceIndex2020": 88.2,
+            "yearOnYearPct": 9.5,
+            "soldHomes": 20892,
+            "averagePurchasePriceEur": 294203
+          },
+          {
+            "period": "2018-09",
+            "priceIndex2020": 88.5,
+            "yearOnYearPct": 9.5,
+            "soldHomes": 16449,
+            "averagePurchasePriceEur": 291218
+          },
+          {
+            "period": "2018-10",
+            "priceIndex2020": 88.8,
+            "yearOnYearPct": 9.2,
+            "soldHomes": 18809,
+            "averagePurchasePriceEur": 294050
+          },
+          {
+            "period": "2018-11",
+            "priceIndex2020": 89.7,
+            "yearOnYearPct": 9.7,
+            "soldHomes": 18292,
+            "averagePurchasePriceEur": 297502
+          },
+          {
+            "period": "2018-12",
+            "priceIndex2020": 89.2,
+            "yearOnYearPct": 8.6,
+            "soldHomes": 19434,
+            "averagePurchasePriceEur": 288356
+          },
+          {
+            "period": "2019-01",
+            "priceIndex2020": 90.7,
+            "yearOnYearPct": 9.0,
+            "soldHomes": 15125,
+            "averagePurchasePriceEur": 302157
+          },
+          {
+            "period": "2019-02",
+            "priceIndex2020": 90.5,
+            "yearOnYearPct": 7.8,
+            "soldHomes": 15470,
+            "averagePurchasePriceEur": 298717
+          },
+          {
+            "period": "2019-03",
+            "priceIndex2020": 90.9,
+            "yearOnYearPct": 7.9,
+            "soldHomes": 16836,
+            "averagePurchasePriceEur": 302845
+          },
+          {
+            "period": "2019-04",
+            "priceIndex2020": 91.4,
+            "yearOnYearPct": 7.9,
+            "soldHomes": 17303,
+            "averagePurchasePriceEur": 302456
+          },
+          {
+            "period": "2019-05",
+            "priceIndex2020": 91.8,
+            "yearOnYearPct": 7.4,
+            "soldHomes": 19708,
+            "averagePurchasePriceEur": 303240
+          },
+          {
+            "period": "2019-06",
+            "priceIndex2020": 92.2,
+            "yearOnYearPct": 7.0,
+            "soldHomes": 15495,
+            "averagePurchasePriceEur": 301736
+          },
+          {
+            "period": "2019-07",
+            "priceIndex2020": 93.2,
+            "yearOnYearPct": 7.1,
+            "soldHomes": 21039,
+            "averagePurchasePriceEur": 309689
+          },
+          {
+            "period": "2019-08",
+            "priceIndex2020": 93.3,
+            "yearOnYearPct": 5.8,
+            "soldHomes": 19583,
+            "averagePurchasePriceEur": 316183
+          },
+          {
+            "period": "2019-09",
+            "priceIndex2020": 93.9,
+            "yearOnYearPct": 6.1,
+            "soldHomes": 18313,
+            "averagePurchasePriceEur": 314225
+          },
+          {
+            "period": "2019-10",
+            "priceIndex2020": 94.4,
+            "yearOnYearPct": 6.3,
+            "soldHomes": 18804,
+            "averagePurchasePriceEur": 312772
+          },
+          {
+            "period": "2019-11",
+            "priceIndex2020": 94.9,
+            "yearOnYearPct": 5.8,
+            "soldHomes": 18346,
+            "averagePurchasePriceEur": 312866
+          },
+          {
+            "period": "2019-12",
+            "priceIndex2020": 95.0,
+            "yearOnYearPct": 6.6,
+            "soldHomes": 22573,
+            "averagePurchasePriceEur": 312957
+          },
+          {
+            "period": "2020-01",
+            "priceIndex2020": 96.4,
+            "yearOnYearPct": 6.3,
+            "soldHomes": 17525,
+            "averagePurchasePriceEur": 329450
+          },
+          {
+            "period": "2020-02",
+            "priceIndex2020": 96.7,
+            "yearOnYearPct": 6.9,
+            "soldHomes": 15427,
+            "averagePurchasePriceEur": 320889
+          },
+          {
+            "period": "2020-03",
+            "priceIndex2020": 97.5,
+            "yearOnYearPct": 7.3,
+            "soldHomes": 18627,
+            "averagePurchasePriceEur": 326529
+          },
+          {
+            "period": "2020-04",
+            "priceIndex2020": 98.3,
+            "yearOnYearPct": 7.6,
+            "soldHomes": 18854,
+            "averagePurchasePriceEur": 326232
+          },
+          {
+            "period": "2020-05",
+            "priceIndex2020": 99.1,
+            "yearOnYearPct": 7.9,
+            "soldHomes": 18347,
+            "averagePurchasePriceEur": 333093
+          },
+          {
+            "period": "2020-06",
+            "priceIndex2020": 99.3,
+            "yearOnYearPct": 7.7,
+            "soldHomes": 17722,
+            "averagePurchasePriceEur": 324195
+          },
+          {
+            "period": "2020-07",
+            "priceIndex2020": 100.3,
+            "yearOnYearPct": 7.6,
+            "soldHomes": 22571,
+            "averagePurchasePriceEur": 336957
+          },
+          {
+            "period": "2020-08",
+            "priceIndex2020": 101.1,
+            "yearOnYearPct": 8.3,
+            "soldHomes": 19034,
+            "averagePurchasePriceEur": 336277
+          },
+          {
+            "period": "2020-09",
+            "priceIndex2020": 102.1,
+            "yearOnYearPct": 8.7,
+            "soldHomes": 20601,
+            "averagePurchasePriceEur": 345443
+          },
+          {
+            "period": "2020-10",
+            "priceIndex2020": 103.0,
+            "yearOnYearPct": 9.1,
+            "soldHomes": 22146,
+            "averagePurchasePriceEur": 350244
+          },
+          {
+            "period": "2020-11",
+            "priceIndex2020": 103.3,
+            "yearOnYearPct": 8.9,
+            "soldHomes": 18449,
+            "averagePurchasePriceEur": 344217
+          },
+          {
+            "period": "2020-12",
+            "priceIndex2020": 102.9,
+            "yearOnYearPct": 8.3,
+            "soldHomes": 26208,
+            "averagePurchasePriceEur": 333199
+          },
+          {
+            "period": "2021-01",
+            "priceIndex2020": 105.4,
+            "yearOnYearPct": 9.3,
+            "soldHomes": 24516,
+            "averagePurchasePriceEur": 357458
+          },
+          {
+            "period": "2021-02",
+            "priceIndex2020": 106.6,
+            "yearOnYearPct": 10.2,
+            "soldHomes": 16871,
+            "averagePurchasePriceEur": 369070
+          },
+          {
+            "period": "2021-03",
+            "priceIndex2020": 108.3,
+            "yearOnYearPct": 11.1,
+            "soldHomes": 25240,
+            "averagePurchasePriceEur": 407014
+          },
+          {
+            "period": "2021-04",
+            "priceIndex2020": 109.4,
+            "yearOnYearPct": 11.2,
+            "soldHomes": 18954,
+            "averagePurchasePriceEur": 362525
+          },
+          {
+            "period": "2021-05",
+            "priceIndex2020": 111.7,
+            "yearOnYearPct": 12.8,
+            "soldHomes": 16126,
+            "averagePurchasePriceEur": 361001
+          },
+          {
+            "period": "2021-06",
+            "priceIndex2020": 113.7,
+            "yearOnYearPct": 14.5,
+            "soldHomes": 17707,
+            "averagePurchasePriceEur": 373384
+          },
+          {
+            "period": "2021-07",
+            "priceIndex2020": 116.4,
+            "yearOnYearPct": 16.1,
+            "soldHomes": 19043,
+            "averagePurchasePriceEur": 395786
+          },
+          {
+            "period": "2021-08",
+            "priceIndex2020": 118.9,
+            "yearOnYearPct": 17.6,
+            "soldHomes": 17257,
+            "averagePurchasePriceEur": 402308
+          },
+          {
+            "period": "2021-09",
+            "priceIndex2020": 120.7,
+            "yearOnYearPct": 18.3,
+            "soldHomes": 17575,
+            "averagePurchasePriceEur": 405165
+          },
+          {
+            "period": "2021-10",
+            "priceIndex2020": 121.8,
+            "yearOnYearPct": 18.2,
+            "soldHomes": 16191,
+            "averagePurchasePriceEur": 408987
+          },
+          {
+            "period": "2021-11",
+            "priceIndex2020": 124.0,
+            "yearOnYearPct": 20.0,
+            "soldHomes": 16048,
+            "averagePurchasePriceEur": 403941
+          },
+          {
+            "period": "2021-12",
+            "priceIndex2020": 123.7,
+            "yearOnYearPct": 20.2,
+            "soldHomes": 20559,
+            "averagePurchasePriceEur": 396848
+          },
+          {
+            "period": "2022-01",
+            "priceIndex2020": 127.4,
+            "yearOnYearPct": 20.9,
+            "soldHomes": 14053,
+            "averagePurchasePriceEur": 434886
+          },
+          {
+            "period": "2022-02",
+            "priceIndex2020": 127.9,
+            "yearOnYearPct": 20.0,
+            "soldHomes": 14037,
+            "averagePurchasePriceEur": 419361
+          },
+          {
+            "period": "2022-03",
+            "priceIndex2020": 129.3,
+            "yearOnYearPct": 19.4,
+            "soldHomes": 15833,
+            "averagePurchasePriceEur": 426183
+          },
+          {
+            "period": "2022-04",
+            "priceIndex2020": 130.7,
+            "yearOnYearPct": 19.6,
+            "soldHomes": 15972,
+            "averagePurchasePriceEur": 429020
+          },
+          {
+            "period": "2022-05",
+            "priceIndex2020": 132.3,
+            "yearOnYearPct": 18.4,
+            "soldHomes": 15749,
+            "averagePurchasePriceEur": 429077
+          },
+          {
+            "period": "2022-06",
+            "priceIndex2020": 132.4,
+            "yearOnYearPct": 16.4,
+            "soldHomes": 15661,
+            "averagePurchasePriceEur": 428932
+          },
+          {
+            "period": "2022-07",
+            "priceIndex2020": 132.9,
+            "yearOnYearPct": 14.2,
+            "soldHomes": 16417,
+            "averagePurchasePriceEur": 445241
+          },
+          {
+            "period": "2022-08",
+            "priceIndex2020": 132.7,
+            "yearOnYearPct": 11.6,
+            "soldHomes": 16405,
+            "averagePurchasePriceEur": 446263
+          },
+          {
+            "period": "2022-09",
+            "priceIndex2020": 131.7,
+            "yearOnYearPct": 9.1,
+            "soldHomes": 17631,
+            "averagePurchasePriceEur": 437996
+          },
+          {
+            "period": "2022-10",
+            "priceIndex2020": 130.9,
+            "yearOnYearPct": 7.5,
+            "soldHomes": 14863,
+            "averagePurchasePriceEur": 428079
+          },
+          {
+            "period": "2022-11",
+            "priceIndex2020": 129.6,
+            "yearOnYearPct": 4.5,
+            "soldHomes": 15146,
+            "averagePurchasePriceEur": 423124
+          },
+          {
+            "period": "2022-12",
+            "priceIndex2020": 126.5,
+            "yearOnYearPct": 2.2,
+            "soldHomes": 21336,
+            "averagePurchasePriceEur": 401436
+          },
+          {
+            "period": "2023-01",
+            "priceIndex2020": 128.2,
+            "yearOnYearPct": 0.7,
+            "soldHomes": 13126,
+            "averagePurchasePriceEur": 424681
+          },
+          {
+            "period": "2023-02",
+            "priceIndex2020": 126.4,
+            "yearOnYearPct": -1.2,
+            "soldHomes": 11858,
+            "averagePurchasePriceEur": 410189
+          },
+          {
+            "period": "2023-03",
+            "priceIndex2020": 125.9,
+            "yearOnYearPct": -2.6,
+            "soldHomes": 15453,
+            "averagePurchasePriceEur": 415141
+          },
+          {
+            "period": "2023-04",
+            "priceIndex2020": 124.6,
+            "yearOnYearPct": -4.7,
+            "soldHomes": 12816,
+            "averagePurchasePriceEur": 401374
+          },
+          {
+            "period": "2023-05",
+            "priceIndex2020": 124.6,
+            "yearOnYearPct": -5.8,
+            "soldHomes": 15099,
+            "averagePurchasePriceEur": 403913
+          },
+          {
+            "period": "2023-06",
+            "priceIndex2020": 124.9,
+            "yearOnYearPct": -5.7,
+            "soldHomes": 16585,
+            "averagePurchasePriceEur": 412943
+          },
+          {
+            "period": "2023-07",
+            "priceIndex2020": 125.6,
+            "yearOnYearPct": -5.5,
+            "soldHomes": 14925,
+            "averagePurchasePriceEur": 413917
+          },
+          {
+            "period": "2023-08",
+            "priceIndex2020": 126.4,
+            "yearOnYearPct": -4.7,
+            "soldHomes": 15934,
+            "averagePurchasePriceEur": 416595
+          },
+          {
+            "period": "2023-09",
+            "priceIndex2020": 127.2,
+            "yearOnYearPct": -3.4,
+            "soldHomes": 16089,
+            "averagePurchasePriceEur": 422175
+          },
+          {
+            "period": "2023-10",
+            "priceIndex2020": 128.1,
+            "yearOnYearPct": -2.1,
+            "soldHomes": 15705,
+            "averagePurchasePriceEur": 424521
+          },
+          {
+            "period": "2023-11",
+            "priceIndex2020": 128.7,
+            "yearOnYearPct": -0.6,
+            "soldHomes": 15248,
+            "averagePurchasePriceEur": 421284
+          },
+          {
+            "period": "2023-12",
+            "priceIndex2020": 129.0,
+            "yearOnYearPct": 1.9,
+            "soldHomes": 19565,
+            "averagePurchasePriceEur": 422372
+          },
+          {
+            "period": "2024-01",
+            "priceIndex2020": 130.5,
+            "yearOnYearPct": 1.8,
+            "soldHomes": 14452,
+            "averagePurchasePriceEur": 433285
+          },
+          {
+            "period": "2024-02",
+            "priceIndex2020": 131.8,
+            "yearOnYearPct": 4.3,
+            "soldHomes": 13810,
+            "averagePurchasePriceEur": 427279
+          },
+          {
+            "period": "2024-03",
+            "priceIndex2020": 132.7,
+            "yearOnYearPct": 5.4,
+            "soldHomes": 16179,
+            "averagePurchasePriceEur": 435049
+          },
+          {
+            "period": "2024-04",
+            "priceIndex2020": 133.9,
+            "yearOnYearPct": 7.5,
+            "soldHomes": 15689,
+            "averagePurchasePriceEur": 435984
+          },
+          {
+            "period": "2024-05",
+            "priceIndex2020": 135.4,
+            "yearOnYearPct": 8.6,
+            "soldHomes": 17591,
+            "averagePurchasePriceEur": 445430
+          },
+          {
+            "period": "2024-06",
+            "priceIndex2020": 137.1,
+            "yearOnYearPct": 9.7,
+            "soldHomes": 14662,
+            "averagePurchasePriceEur": 441112
+          },
+          {
+            "period": "2024-07",
+            "priceIndex2020": 139.0,
+            "yearOnYearPct": 10.6,
+            "soldHomes": 18610,
+            "averagePurchasePriceEur": 457320
+          },
+          {
+            "period": "2024-08",
+            "priceIndex2020": 140.5,
+            "yearOnYearPct": 11.2,
+            "soldHomes": 17915,
+            "averagePurchasePriceEur": 466207
+          },
+          {
+            "period": "2024-09",
+            "priceIndex2020": 141.7,
+            "yearOnYearPct": 11.4,
+            "soldHomes": 17622,
+            "averagePurchasePriceEur": 466890
+          },
+          {
+            "period": "2024-10",
+            "priceIndex2020": 142.8,
+            "yearOnYearPct": 11.5,
+            "soldHomes": 18131,
+            "averagePurchasePriceEur": 467355
+          },
+          {
+            "period": "2024-11",
+            "priceIndex2020": 144.1,
+            "yearOnYearPct": 11.9,
+            "soldHomes": 17973,
+            "averagePurchasePriceEur": 461931
+          },
+          {
+            "period": "2024-12",
+            "priceIndex2020": 143.1,
+            "yearOnYearPct": 11.0,
+            "soldHomes": 23824,
+            "averagePurchasePriceEur": 457467
+          },
+          {
+            "period": "2025-01",
+            "priceIndex2020": 145.5,
+            "yearOnYearPct": 11.5,
+            "soldHomes": 17907,
+            "averagePurchasePriceEur": 474534
+          },
+          {
+            "period": "2025-02",
+            "priceIndex2020": 145.7,
+            "yearOnYearPct": 10.6,
+            "soldHomes": 16356,
+            "averagePurchasePriceEur": 467363
+          },
+          {
+            "period": "2025-03",
+            "priceIndex2020": 146.7,
+            "yearOnYearPct": 10.6,
+            "soldHomes": 17211,
+            "averagePurchasePriceEur": 467873
+          },
+          {
+            "period": "2025-04",
+            "priceIndex2020": 147.6,
+            "yearOnYearPct": 10.2,
+            "soldHomes": 18915,
+            "averagePurchasePriceEur": 472054
+          },
+          {
+            "period": "2025-05",
+            "priceIndex2020": 148.5,
+            "yearOnYearPct": 9.7,
+            "soldHomes": 19614,
+            "averagePurchasePriceEur": 471875
+          },
+          {
+            "period": "2025-06",
+            "priceIndex2020": 149.8,
+            "yearOnYearPct": 9.3,
+            "soldHomes": 18883,
+            "averagePurchasePriceEur": 474234
+          },
+          {
+            "period": "2025-07",
+            "priceIndex2020": 150.9,
+            "yearOnYearPct": 8.6,
+            "soldHomes": 21189,
+            "averagePurchasePriceEur": 486041
+          },
+          {
+            "period": "2025-08",
+            "priceIndex2020": 151.6,
+            "yearOnYearPct": 7.9,
+            "soldHomes": 19459,
+            "averagePurchasePriceEur": 486190
+          },
+          {
+            "period": "2025-09",
+            "priceIndex2020": 151.6,
+            "yearOnYearPct": 7.0,
+            "soldHomes": 21934,
+            "averagePurchasePriceEur": 489072
+          },
+          {
+            "period": "2025-10",
+            "priceIndex2020": 152.3,
+            "yearOnYearPct": 6.6,
+            "soldHomes": 21849,
+            "averagePurchasePriceEur": 498996
+          },
+          {
+            "period": "2025-11",
+            "priceIndex2020": 152.8,
+            "yearOnYearPct": 6.1,
+            "soldHomes": 18224,
+            "averagePurchasePriceEur": 477531
+          },
+          {
+            "period": "2025-12",
+            "priceIndex2020": 151.4,
+            "yearOnYearPct": 5.8,
+            "soldHomes": 27154,
+            "averagePurchasePriceEur": 480051
+          },
+          {
+            "period": "2026-01",
+            "priceIndex2020": 153.3,
+            "yearOnYearPct": 5.4,
+            "soldHomes": 18893,
+            "averagePurchasePriceEur": 493875
+          },
+          {
+            "period": "2026-02",
+            "priceIndex2020": 153.5,
+            "yearOnYearPct": 5.4,
+            "soldHomes": 17675,
+            "averagePurchasePriceEur": 487768
+          },
+          {
+            "period": "2026-03",
+            "priceIndex2020": 154.0,
+            "yearOnYearPct": 5.0,
+            "soldHomes": 19381,
+            "averagePurchasePriceEur": 494605
+          },
+          {
+            "period": "2026-04",
+            "priceIndex2020": 154.0,
+            "yearOnYearPct": 4.3,
+            "soldHomes": 19454,
+            "averagePurchasePriceEur": 486101
+          },
+          {
+            "period": "2026-05",
+            "priceIndex2020": 154.9,
+            "yearOnYearPct": 4.4,
+            "soldHomes": 19120,
+            "averagePurchasePriceEur": 487383
+          },
+          {
+            "period": "2026-06",
+            "priceIndex2020": 155.9,
+            "yearOnYearPct": 4.1,
+            "soldHomes": 20378,
+            "averagePurchasePriceEur": 496235
+          }
+        ],
+        "latest": {
+          "period": "2026-06",
+          "priceIndex2020": 155.9,
+          "yearOnYearPct": 4.1,
+          "soldHomes": 20378,
+          "averagePurchasePriceEur": 496235
+        },
+        "sourceId": "cbs-existing-homes",
+        "note": "Average purchase price is descriptive and is not corrected for changes in the mix of homes sold; the price index is the quality-adjusted measure."
+      }
+    },
+    "ecbMortgage": {
+      "unit": "% per year",
+      "definition": "Annualised agreed rate on new euro-denominated loans to Dutch households for house purchase, all initial fixation periods.",
+      "observations": [
+        {
+          "period": "2015-01",
+          "value": 3.1
+        },
+        {
+          "period": "2015-02",
+          "value": 3.1
+        },
+        {
+          "period": "2015-03",
+          "value": 3.0
+        },
+        {
+          "period": "2015-04",
+          "value": 3.0
+        },
+        {
+          "period": "2015-05",
+          "value": 2.9
+        },
+        {
+          "period": "2015-06",
+          "value": 2.9
+        },
+        {
+          "period": "2015-07",
+          "value": 2.9
+        },
+        {
+          "period": "2015-08",
+          "value": 2.9
+        },
+        {
+          "period": "2015-09",
+          "value": 2.9
+        },
+        {
+          "period": "2015-10",
+          "value": 2.9
+        },
+        {
+          "period": "2015-11",
+          "value": 2.9
+        },
+        {
+          "period": "2015-12",
+          "value": 2.8
+        },
+        {
+          "period": "2016-01",
+          "value": 2.8
+        },
+        {
+          "period": "2016-02",
+          "value": 2.8
+        },
+        {
+          "period": "2016-03",
+          "value": 2.7
+        },
+        {
+          "period": "2016-04",
+          "value": 2.7
+        },
+        {
+          "period": "2016-05",
+          "value": 2.6
+        },
+        {
+          "period": "2016-06",
+          "value": 2.6
+        },
+        {
+          "period": "2016-07",
+          "value": 2.6
+        },
+        {
+          "period": "2016-08",
+          "value": 2.5
+        },
+        {
+          "period": "2016-09",
+          "value": 2.5
+        },
+        {
+          "period": "2016-10",
+          "value": 2.4
+        },
+        {
+          "period": "2016-11",
+          "value": 2.4
+        },
+        {
+          "period": "2016-12",
+          "value": 2.4
+        },
+        {
+          "period": "2017-01",
+          "value": 2.4
+        },
+        {
+          "period": "2017-02",
+          "value": 2.4
+        },
+        {
+          "period": "2017-03",
+          "value": 2.4
+        },
+        {
+          "period": "2017-04",
+          "value": 2.4
+        },
+        {
+          "period": "2017-05",
+          "value": 2.4
+        },
+        {
+          "period": "2017-06",
+          "value": 2.4
+        },
+        {
+          "period": "2017-07",
+          "value": 2.4
+        },
+        {
+          "period": "2017-08",
+          "value": 2.4
+        },
+        {
+          "period": "2017-09",
+          "value": 2.4
+        },
+        {
+          "period": "2017-10",
+          "value": 2.4
+        },
+        {
+          "period": "2017-11",
+          "value": 2.4
+        },
+        {
+          "period": "2017-12",
+          "value": 2.4
+        },
+        {
+          "period": "2018-01",
+          "value": 2.4
+        },
+        {
+          "period": "2018-02",
+          "value": 2.4
+        },
+        {
+          "period": "2018-03",
+          "value": 2.4
+        },
+        {
+          "period": "2018-04",
+          "value": 2.4
+        },
+        {
+          "period": "2018-05",
+          "value": 2.4
+        },
+        {
+          "period": "2018-06",
+          "value": 2.4
+        },
+        {
+          "period": "2018-07",
+          "value": 2.4
+        },
+        {
+          "period": "2018-08",
+          "value": 2.4
+        },
+        {
+          "period": "2018-09",
+          "value": 2.4
+        },
+        {
+          "period": "2018-10",
+          "value": 2.4
+        },
+        {
+          "period": "2018-11",
+          "value": 2.4
+        },
+        {
+          "period": "2018-12",
+          "value": 2.4
+        },
+        {
+          "period": "2019-01",
+          "value": 2.4
+        },
+        {
+          "period": "2019-02",
+          "value": 2.4
+        },
+        {
+          "period": "2019-03",
+          "value": 2.4
+        },
+        {
+          "period": "2019-04",
+          "value": 2.4
+        },
+        {
+          "period": "2019-05",
+          "value": 2.3
+        },
+        {
+          "period": "2019-06",
+          "value": 2.3
+        },
+        {
+          "period": "2019-07",
+          "value": 2.2
+        },
+        {
+          "period": "2019-08",
+          "value": 2.2
+        },
+        {
+          "period": "2019-09",
+          "value": 2.1
+        },
+        {
+          "period": "2019-10",
+          "value": 2.1
+        },
+        {
+          "period": "2019-11",
+          "value": 2.4
+        },
+        {
+          "period": "2019-12",
+          "value": 2.0
+        },
+        {
+          "period": "2020-01",
+          "value": 2.0
+        },
+        {
+          "period": "2020-02",
+          "value": 1.9
+        },
+        {
+          "period": "2020-03",
+          "value": 1.9
+        },
+        {
+          "period": "2020-04",
+          "value": 1.9
+        },
+        {
+          "period": "2020-05",
+          "value": 1.9
+        },
+        {
+          "period": "2020-06",
+          "value": 1.9
+        },
+        {
+          "period": "2020-07",
+          "value": 1.9
+        },
+        {
+          "period": "2020-08",
+          "value": 1.9
+        },
+        {
+          "period": "2020-09",
+          "value": 1.9
+        },
+        {
+          "period": "2020-10",
+          "value": 1.9
+        },
+        {
+          "period": "2020-11",
+          "value": 1.9
+        },
+        {
+          "period": "2020-12",
+          "value": 1.8
+        },
+        {
+          "period": "2021-01",
+          "value": 1.8
+        },
+        {
+          "period": "2021-02",
+          "value": 1.8
+        },
+        {
+          "period": "2021-03",
+          "value": 1.8
+        },
+        {
+          "period": "2021-04",
+          "value": 1.7
+        },
+        {
+          "period": "2021-05",
+          "value": 1.7
+        },
+        {
+          "period": "2021-06",
+          "value": 1.7
+        },
+        {
+          "period": "2021-07",
+          "value": 1.7
+        },
+        {
+          "period": "2021-08",
+          "value": 1.7
+        },
+        {
+          "period": "2021-09",
+          "value": 1.6
+        },
+        {
+          "period": "2021-10",
+          "value": 1.6
+        },
+        {
+          "period": "2021-11",
+          "value": 1.6
+        },
+        {
+          "period": "2021-12",
+          "value": 1.6
+        },
+        {
+          "period": "2022-01",
+          "value": 1.7
+        },
+        {
+          "period": "2022-02",
+          "value": 1.7
+        },
+        {
+          "period": "2022-03",
+          "value": 1.8
+        },
+        {
+          "period": "2022-04",
+          "value": 1.9
+        },
+        {
+          "period": "2022-05",
+          "value": 2.0
+        },
+        {
+          "period": "2022-06",
+          "value": 2.2
+        },
+        {
+          "period": "2022-07",
+          "value": 2.4
+        },
+        {
+          "period": "2022-08",
+          "value": 2.6
+        },
+        {
+          "period": "2022-09",
+          "value": 2.8
+        },
+        {
+          "period": "2022-10",
+          "value": 3.1
+        },
+        {
+          "period": "2022-11",
+          "value": 3.2
+        },
+        {
+          "period": "2022-12",
+          "value": 3.4
+        },
+        {
+          "period": "2023-01",
+          "value": 3.5
+        },
+        {
+          "period": "2023-02",
+          "value": 3.6
+        },
+        {
+          "period": "2023-03",
+          "value": 3.5
+        },
+        {
+          "period": "2023-04",
+          "value": 3.7
+        },
+        {
+          "period": "2023-05",
+          "value": 3.8
+        },
+        {
+          "period": "2023-06",
+          "value": 3.9
+        },
+        {
+          "period": "2023-07",
+          "value": 4.0
+        },
+        {
+          "period": "2023-08",
+          "value": 4.0
+        },
+        {
+          "period": "2023-09",
+          "value": 4.0
+        },
+        {
+          "period": "2023-10",
+          "value": 3.8
+        },
+        {
+          "period": "2023-11",
+          "value": 4.1
+        },
+        {
+          "period": "2023-12",
+          "value": 4.1
+        },
+        {
+          "period": "2024-01",
+          "value": 4.0
+        },
+        {
+          "period": "2024-02",
+          "value": 3.9
+        },
+        {
+          "period": "2024-03",
+          "value": 3.8
+        },
+        {
+          "period": "2024-04",
+          "value": 3.8
+        },
+        {
+          "period": "2024-05",
+          "value": 3.8
+        },
+        {
+          "period": "2024-06",
+          "value": 3.8
+        },
+        {
+          "period": "2024-07",
+          "value": 3.9
+        },
+        {
+          "period": "2024-08",
+          "value": 3.8
+        },
+        {
+          "period": "2024-09",
+          "value": 3.9
+        },
+        {
+          "period": "2024-10",
+          "value": 3.7
+        },
+        {
+          "period": "2024-11",
+          "value": 3.7
+        },
+        {
+          "period": "2024-12",
+          "value": 3.6
+        },
+        {
+          "period": "2025-01",
+          "value": 2.8
+        },
+        {
+          "period": "2025-02",
+          "value": 3.5
+        },
+        {
+          "period": "2025-03",
+          "value": 3.5
+        },
+        {
+          "period": "2025-04",
+          "value": 3.0
+        },
+        {
+          "period": "2025-05",
+          "value": 3.5
+        },
+        {
+          "period": "2025-06",
+          "value": 3.6
+        },
+        {
+          "period": "2025-07",
+          "value": 3.5
+        },
+        {
+          "period": "2025-08",
+          "value": 3.5
+        },
+        {
+          "period": "2025-09",
+          "value": 3.5
+        },
+        {
+          "period": "2025-10",
+          "value": 3.5
+        },
+        {
+          "period": "2025-11",
+          "value": 3.5
+        },
+        {
+          "period": "2025-12",
+          "value": 3.5
+        },
+        {
+          "period": "2026-01",
+          "value": 3.5
+        },
+        {
+          "period": "2026-02",
+          "value": 3.6
+        },
+        {
+          "period": "2026-03",
+          "value": 3.5
+        },
+        {
+          "period": "2026-04",
+          "value": 3.6
+        },
+        {
+          "period": "2026-05",
+          "value": 3.7
+        }
+      ],
+      "latest": {
+        "period": "2026-05",
+        "value": 3.7
+      },
+      "lowSince2015": {
+        "period": "2021-09",
+        "value": 1.6
+      },
+      "sourceId": "ecb-mortgage"
+    },
+    "overburden": {
+      "definition": "Share of people whose total housing costs exceed 40% of disposable household income, after housing allowances.",
+      "byTenure": [
+        {
+          "code": "OWN_L",
+          "tenure": "Owner with mortgage",
+          "value": 1.1
+        },
+        {
+          "code": "OWN_NL",
+          "tenure": "Owner without mortgage",
+          "value": 3.0
+        },
+        {
+          "code": "RENT_MKT",
+          "tenure": "Market-rate tenant",
+          "value": 39.5
+        },
+        {
+          "code": "RENT_FR",
+          "tenure": "Reduced/free-rent tenant",
+          "value": 12.9
+        }
+      ],
+      "period": "2025",
+      "totalPct": 6.5,
+      "sourceId": "eurostat-overburden"
+    },
+    "tenure": {
+      "period": "2025",
+      "shares": {
+        "NL": {
+          "OWN": 68.8,
+          "RENT_MKT": 5.5,
+          "RENT_FR": 25.7
+        },
+        "EU27_2020": {
+          "OWN": 68.5,
+          "RENT_MKT": 20.8,
+          "RENT_FR": 10.7
+        }
+      },
+      "sourceId": "eurostat-tenure",
+      "note": "Rent at reduced price or free includes social, subsidised and other below-market arrangements; categories are population shares, not dwelling-stock shares."
+    },
+    "supplyVsHouseholds": [
+      {
+        "year": 2018,
+        "newConstruction": 66585,
+        "netHousingAddition": 73921,
+        "householdsStart": 7857914,
+        "householdsEnd": 7924691,
+        "householdGrowth": 66777
+      },
+      {
+        "year": 2019,
+        "newConstruction": 71548,
+        "netHousingAddition": 76872,
+        "householdsStart": 7924691,
+        "householdsEnd": 7997800,
+        "householdGrowth": 73109
+      },
+      {
+        "year": 2020,
+        "newConstruction": 69985,
+        "netHousingAddition": 74543,
+        "householdsStart": 7997800,
+        "householdsEnd": 8043443,
+        "householdGrowth": 45643
+      },
+      {
+        "year": 2021,
+        "newConstruction": 71221,
+        "netHousingAddition": 79250,
+        "householdsStart": 8043443,
+        "householdsEnd": 8138591,
+        "householdGrowth": 95148
+      },
+      {
+        "year": 2022,
+        "newConstruction": 74560,
+        "netHousingAddition": 79649,
+        "householdsStart": 8138591,
+        "householdsEnd": 8270244,
+        "householdGrowth": 131653
+      },
+      {
+        "year": 2023,
+        "newConstruction": 73638,
+        "netHousingAddition": 78819,
+        "householdsStart": 8270244,
+        "householdsEnd": 8374404,
+        "householdGrowth": 104160
+      },
+      {
+        "year": 2024,
+        "newConstruction": 69129,
+        "netHousingAddition": 70420,
+        "householdsStart": 8374404,
+        "householdsEnd": 8430352,
+        "householdGrowth": 55948
+      }
+    ],
+    "latestSupply": {
+      "year": 2025,
+      "newConstruction": 69189,
+      "netHousingAddition": 70428,
+      "householdComparatorAvailable": false,
+      "sourceIds": [
+        "cbs-housing-stock",
+        "cbs-households"
+      ],
+      "note": "Households are measured on 1 January. Each aligned row compares stock change during the year with the change in private households from 1 January of that year to 1 January of the next."
+    }
+  },
+  "comparisons": {
+    "measure": "Price-to-income index",
+    "base": "2015=100",
+    "period": "2025-Q4",
+    "countries": [
+      {
+        "code": "NLD",
+        "name": "Netherlands",
+        "value": 135.5,
+        "whyIncluded": "Primary context: rapid post-2015 deterioration despite a large regulated-rental sector."
+      },
+      {
+        "code": "DEU",
+        "name": "Germany",
+        "value": 107.5,
+        "whyIncluded": "A renter-majority contrast with a smaller post-2015 price-to-income shift."
+      },
+      {
+        "code": "ESP",
+        "name": "Spain",
+        "value": 128.6,
+        "whyIncluded": "A high-ownership market shaped by a different construction cycle after the euro-area housing crash."
+      },
+      {
+        "code": "CAN",
+        "name": "Canada",
+        "value": 128.0,
+        "whyIncluded": "A non-European high-income market with strong population growth and pronounced urban supply pressure."
+      },
+      {
+        "code": "JPN",
+        "name": "Japan",
+        "value": 114.1,
+        "whyIncluded": "An aging-country contrast where national abundance can coexist with scarcity in the largest cities."
+      },
+      {
+        "code": "AUT",
+        "name": "Austria",
+        "value": 119.0,
+        "whyIncluded": "A European contrast with substantial social and limited-profit housing, especially in Vienna."
+      }
+    ],
+    "caveat": "This is not an absolute affordability ranking. Each country is indexed to its own 2015 price-to-income relationship; the comparison shows direction and scale of change, not how many years of income a home costs."
+  },
+  "interpretation": {
+    "currentConclusion": "Attainability has not broadly recovered in the Netherlands. Prices relative to incomes remain far above 2015, mortgage rates are well above their 2021 low, and market-rate tenants carry a disproportionate cost burden.",
+    "established": [
+      "Dutch existing-home prices are again rising year over year.",
+      "House prices have risen much faster than rents and disposable income since 2015.",
+      "Housing-cost overburden is highly unequal across tenure groups.",
+      "Recent net additions to the dwelling stock can exceed annual household growth without resolving accumulated shortages or mismatch."
+    ],
+    "notEstablished": [
+      "A single national shortage number fully explains price movements.",
+      "Falling nominal prices automatically improve affordability when mortgage rates or incomes move against buyers.",
+      "A country with a lower indexed change is necessarily more affordable in absolute terms.",
+      "More units anywhere, at any tenure or price, reach the households carrying the greatest burden."
+    ],
+    "competingExplanations": [
+      {
+        "title": "Accumulated undersupply",
+        "text": "Household formation, migration, smaller households and constrained building accumulated faster than suitable supply in high-demand places."
+      },
+      {
+        "title": "Credit and rates",
+        "text": "Cheap credit raised purchasing power before 2022; later rate increases reduced borrowing capacity even when prices briefly softened."
+      },
+      {
+        "title": "Income, tax and institutions",
+        "text": "Wages, mortgage-interest treatment, rent regulation, social housing and investor rules change who can bid and who receives protection."
+      },
+      {
+        "title": "Mismatch, not only totals",
+        "text": "Location, size, accessibility, energy quality and tenure can leave people without suitable homes even when the national stock grows."
+      }
+    ],
+    "changeEvidence": [
+      "A sustained fall in price-to-income and price-to-rent ratios, not merely a short nominal-price dip.",
+      "Market-renter overburden moving materially toward the national rate without displacement from the measured group.",
+      "Several years in which suitable, occupied additions outpace household formation in the highest-pressure regions.",
+      "Lower financing costs or stronger real incomes that measurably reduce first-time-buyer payment burdens.",
+      "Better administrative evidence connecting permits, completions, vacancies, tenure, household need and regional waiting times."
+    ],
+    "possibilities": [
+      {
+        "label": "Public capability",
+        "title": "An affordability account, not a price dashboard",
+        "text": "Publish one joined view of prices, rents, incomes, financing, supply, tenure and regional need so policies cannot claim success from one favorable series."
+      },
+      {
+        "label": "Institution",
+        "title": "Faster paths for repeatable, low-carbon housing",
+        "text": "Pre-approved patterns, transparent local constraints and shared infrastructure data could shorten delivery without removing safety or democratic review."
+      },
+      {
+        "label": "Product",
+        "title": "Search by total monthly burden",
+        "text": "Housing tools could compare rent or mortgage, energy, maintenance, tax and transport together rather than optimizing only the listing price."
+      },
+      {
+        "label": "Small lever",
+        "title": "Make existing space usable",
+        "text": "Conversions, splits, accessibility upgrades and matching older households to suitable homes may add effective capacity faster than greenfield construction alone."
+      }
+    ]
+  },
+  "sources": [
+    {
+      "id": "world-bank-slums",
+      "title": "Population living in slums (% of urban population)",
+      "publisher": "World Bank, sourced from UN-Habitat",
+      "url": "https://data.worldbank.org/indicator/EN.POP.SLUM.UR.ZS",
+      "accessed": "2026-07-23",
+      "role": "World housing-adequacy lens and derived affected-population estimate",
+      "kind": "SDG indicator"
+    },
+    {
+      "id": "oecd-house-prices",
+      "title": "Analytical house price indicators",
+      "publisher": "OECD",
+      "url": "https://sdmx.oecd.org/public/rest/v1/data/OECD.ECO.MPD,DSD_AN_HOUSE_PRICES@DF_HOUSE_PRICES,1.0/.",
+      "accessed": "2026-07-23",
+      "role": "Harmonized house-price, rent, price-to-income and price-to-rent indices",
+      "kind": "Official comparative statistics"
+    },
+    {
+      "id": "eurostat-overburden",
+      "title": "Housing cost overburden rate by tenure status",
+      "publisher": "Eurostat",
+      "url": "https://ec.europa.eu/eurostat/databrowser/view/ilc_lvho07c/default/table?lang=en",
+      "accessed": "2026-07-23",
+      "role": "Distribution of housing-cost burden across Dutch tenure groups",
+      "kind": "EU-SILC survey statistic"
+    },
+    {
+      "id": "eurostat-tenure",
+      "title": "Population by tenure status",
+      "publisher": "Eurostat",
+      "url": "https://ec.europa.eu/eurostat/databrowser/view/ilc_lvho02/default/table?lang=en",
+      "accessed": "2026-07-23",
+      "role": "Owner and renter population shares in the Netherlands and EU",
+      "kind": "EU-SILC survey statistic"
+    },
+    {
+      "id": "cbs-existing-homes",
+      "title": "Existing own homes; purchase prices, price indices 2020=100",
+      "publisher": "Statistics Netherlands (CBS)",
+      "url": "https://opendata.cbs.nl/statline/#/CBS/en/dataset/85773ENG",
+      "accessed": "2026-07-23",
+      "role": "Current Dutch existing-home prices, transactions and average purchase price",
+      "kind": "Administrative transaction statistics"
+    },
+    {
+      "id": "cbs-housing-stock",
+      "title": "Housing stock; levels and changes since 1921",
+      "publisher": "Statistics Netherlands (CBS)",
+      "url": "https://opendata.cbs.nl/statline/#/CBS/nl/dataset/82235NED",
+      "accessed": "2026-07-23",
+      "role": "New construction and net dwelling-stock additions",
+      "kind": "Administrative BAG statistics"
+    },
+    {
+      "id": "cbs-households",
+      "title": "Households; composition, size, region, 1 January",
+      "publisher": "Statistics Netherlands (CBS)",
+      "url": "https://opendata.cbs.nl/statline/#/CBS/nl/dataset/71486NED",
+      "accessed": "2026-07-23",
+      "role": "Annual Dutch private-household formation",
+      "kind": "Population statistics"
+    },
+    {
+      "id": "ecb-mortgage",
+      "title": "Bank interest rates — loans to households for house purchase (new business)",
+      "publisher": "European Central Bank / De Nederlandsche Bank",
+      "url": "https://data.ecb.europa.eu/data/datasets/MIR/MIR.M.NL.B.A2C.A.R.A.2250.EUR.N",
+      "accessed": "2026-07-23",
+      "role": "Dutch new-mortgage interest-rate conditions",
+      "kind": "Monetary financial statistics"
+    }
+  ]
+}

--- a/ctw.studio/signals/food/food.css
+++ b/ctw.studio/signals/food/food.css
@@ -1,0 +1,1276 @@
+.food-page {
+  --food: #b8f26d;
+  --food-soft: rgba(184, 242, 109, 0.13);
+  --coral: #ff745e;
+  --coral-soft: rgba(255, 116, 94, 0.12);
+  --water: #58c7ed;
+  --water-soft: rgba(88, 199, 237, 0.12);
+  --amber-soft: rgba(247, 181, 0, 0.12);
+  --serif: Georgia, 'Times New Roman', serif;
+  --radius-md: 1rem;
+  --radius-lg: 1.35rem;
+}
+
+/* Brief 002 shares the system tokens with Brief 001, but uses a more editorial
+   chapter vocabulary. These structural rules intentionally stay local. */
+.food-page .topic-pill {
+  color: inherit;
+  text-decoration: none;
+}
+
+.food-page .topic-label {
+  margin-right: 0.7rem;
+  color: var(--ink);
+  font-weight: 500;
+}
+
+.food-page .topic-pill.future small {
+  margin-left: 0.35rem;
+  color: var(--ink-soft);
+  font-size: inherit;
+}
+
+.brief-id {
+  display: flex;
+  max-width: 41rem;
+  align-items: center;
+  gap: 0.8rem;
+  margin: 0 0 1.2rem;
+  color: var(--food);
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.brief-line {
+  height: 1px;
+  flex: 1;
+  background: linear-gradient(90deg, rgba(184,242,109,0.65), transparent);
+}
+
+.food-page .verdict-topline {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 0.45rem;
+  height: 0.45rem;
+  border-radius: 50%;
+}
+
+.verdict-answer {
+  margin: 2rem 0 0.75rem;
+  color: var(--ink);
+  font-size: clamp(1.45rem, 2.5vw, 2.25rem);
+  font-weight: 650;
+  letter-spacing: -0.045em;
+  line-height: 1.12;
+}
+
+.verdict-copy {
+  color: var(--ink-soft);
+  font-size: 0.84rem;
+  line-height: 1.65;
+}
+
+.verdict-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  margin: 1.5rem 0 0;
+  border-top: 1px solid var(--line);
+}
+
+.verdict-metrics div {
+  padding: 1rem 0.55rem 0.4rem 0;
+}
+
+.verdict-metrics dt {
+  min-height: 2rem;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.54rem;
+  line-height: 1.35;
+  text-transform: uppercase;
+}
+
+.verdict-metrics dd {
+  margin: 0.35rem 0 0;
+  color: var(--food);
+  font-family: var(--mono);
+  font-size: 1.2rem;
+}
+
+.verdict-footnote {
+  margin: 1rem 0 0;
+  color: var(--muted);
+  font-size: 0.65rem;
+  line-height: 1.5;
+}
+
+.scroll-cue {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  margin-top: clamp(3.5rem, 7vw, 6.5rem);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.66rem;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.scroll-cue svg {
+  width: 1.1rem;
+  fill: none;
+  stroke: var(--food);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+}
+
+.food-page .story-index > p {
+  margin: 0 0 1.4rem;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  text-transform: uppercase;
+}
+
+.food-page .story-index nav {
+  border-bottom: 1px solid var(--line);
+}
+
+.food-page .story-index a {
+  border-top: 1px solid var(--line);
+}
+
+.food-page .story-index a.active {
+  color: var(--food);
+  transform: translateX(3px);
+}
+
+.story-chapter {
+  padding: clamp(5rem, 10vw, 9rem) 0;
+  border-bottom: 1px solid var(--line);
+  scroll-margin-top: 6.5rem;
+}
+
+.chapter-head h2 {
+  max-width: 980px;
+  margin: 0;
+  color: var(--ink);
+  font-size: clamp(2.35rem, 5vw, 5rem);
+  font-weight: 650;
+  letter-spacing: -0.055em;
+  line-height: 1.02;
+}
+
+.chapter-head > p:last-child {
+  max-width: 820px;
+  margin: 1.5rem 0 0;
+  color: var(--ink-soft);
+  font-size: clamp(1rem, 1.5vw, 1.18rem);
+  line-height: 1.7;
+}
+
+.chapter-kicker,
+.chart-eyebrow {
+  margin: 0 0 0.7rem;
+  font-family: var(--mono);
+  font-size: 0.67rem;
+  font-weight: 500;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.chapter-kicker span {
+  margin-right: 0.45rem;
+}
+
+.food-page .chart-card {
+  margin: 1rem 0;
+  padding: clamp(1.25rem, 3vw, 2rem);
+}
+
+.chart-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1.2rem;
+}
+
+.chart-head h3 {
+  margin: 0;
+  color: var(--ink);
+  font-size: 1.35rem;
+  letter-spacing: -0.025em;
+}
+
+.scope-chip {
+  flex: 0 0 auto;
+  padding: 0.38rem 0.65rem;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.59rem;
+  text-transform: uppercase;
+}
+
+.food-page figure > figcaption {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.7rem;
+  line-height: 1.55;
+}
+
+.chart-table-wrap {
+  margin-top: 1rem;
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.chart-table-wrap summary {
+  width: fit-content;
+  cursor: pointer;
+  font-family: var(--mono);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.chart-table-scroll {
+  max-height: 18rem;
+  overflow: auto;
+  margin-top: 0.8rem;
+  border: 1px solid var(--line);
+  border-radius: 0.7rem;
+}
+
+.chart-table-scroll table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.chart-table-scroll th,
+.chart-table-scroll td {
+  padding: 0.55rem 0.75rem;
+  border-top: 1px solid var(--line);
+  text-align: left;
+}
+
+.chart-table-scroll td {
+  color: var(--ink-soft);
+}
+
+.boundary-note {
+  display: grid;
+  grid-template-columns: 3rem 1fr;
+  gap: 1.2rem;
+  padding: clamp(1.35rem, 3vw, 2rem);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+}
+
+.boundary-icon {
+  display: grid;
+  width: 2.6rem;
+  height: 2.6rem;
+  place-items: center;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+}
+
+.boundary-note h3 {
+  margin: 0 0 0.5rem;
+  color: var(--ink);
+  font-size: 1rem;
+}
+
+.boundary-note p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+  line-height: 1.65;
+}
+
+.interpretation-row {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  gap: 1rem;
+  margin-top: 1rem;
+  padding: 1.25rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+}
+
+.interpretation-icon {
+  display: grid;
+  width: 2rem;
+  height: 2rem;
+  place-items: center;
+  border-radius: 50%;
+  font-family: var(--mono);
+}
+
+.interpretation-row strong { color: var(--ink); font-size: 0.84rem; }
+.interpretation-row p { margin: 0.25rem 0 0; color: var(--muted); font-size: 0.78rem; line-height: 1.6; }
+
+.conclusion-verdict {
+  margin: 2rem 0 1rem;
+  padding: clamp(1.5rem, 4vw, 2.6rem);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+}
+
+.conclusion-verdict > span {
+  display: block;
+  font-size: clamp(1.5rem, 3.2vw, 2.8rem);
+  font-weight: 650;
+  letter-spacing: -0.045em;
+  line-height: 1.15;
+}
+
+.conclusion-verdict p {
+  max-width: 850px;
+  margin: 1rem 0 0;
+  color: var(--ink-soft);
+  line-height: 1.7;
+}
+
+.food-answer-grid {
+  overflow: hidden;
+  margin: 1rem 0;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+}
+
+.food-answer-grid article { min-height: 17rem; }
+.food-answer-grid h3 { margin: 1rem 0 0.7rem; color: var(--ink); font-size: 1rem; }
+.food-answer-grid p { color: var(--muted); font-size: 0.77rem; line-height: 1.65; }
+
+.answer-mark {
+  display: inline-block;
+  padding: 0.3rem 0.55rem;
+  border-radius: 999px;
+  font-family: var(--mono);
+  font-size: 0.62rem;
+  text-transform: uppercase;
+}
+
+.source-list {
+  margin-top: 1rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+}
+
+.source-item {
+  display: grid;
+  grid-template-columns: 2.6rem 1fr;
+  gap: 1rem;
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--line);
+}
+
+.source-item:last-child { border-bottom: 0; }
+.source-item h3 { margin: 0; font-size: 0.88rem; }
+.source-item a { text-decoration-color: #54534d; text-underline-offset: 4px; }
+.source-item a:hover { color: var(--food); }
+.source-role { margin: 0.4rem 0 0; color: var(--muted); font-size: 0.72rem; }
+.source-kind { display: inline-block; margin-top: 0.65rem; padding: 0.2rem 0.45rem; border: 1px solid var(--line); border-radius: 999px; color: var(--ink-soft); font-family: var(--mono); font-size: 0.55rem; }
+.loading-message { padding: 1rem 1.5rem; color: var(--muted); }
+
+.method-details {
+  margin-top: 1rem;
+  padding: 1.2rem 1.4rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+}
+
+.method-details summary { cursor: pointer; color: var(--ink); font-weight: 600; }
+.method-details p { color: var(--muted); font-size: 0.78rem; line-height: 1.65; }
+.method-details code { color: var(--food); }
+
+.future-card {
+  position: relative;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 2rem;
+  align-items: center;
+  margin: 2rem 0 clamp(5rem,10vw,9rem);
+  padding: clamp(2rem,5vw,4rem);
+  overflow: hidden;
+  border: 1px solid rgba(165,139,255,.24);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(165,139,255,.075), rgba(255,255,255,.015));
+}
+
+.future-card h2 { max-width: 720px; margin: 0; font-size: clamp(2rem,4vw,4rem); letter-spacing: -.055em; line-height: 1.05; }
+.future-card div > p:last-child { max-width: 700px; color: var(--muted); font-size: .9rem; }
+.future-tag { padding: 0.55rem 0.8rem; border: 1px solid rgba(165,139,255,.3); border-radius: 999px; color: var(--violet); font-family: var(--mono); font-size: 0.6rem; text-transform: uppercase; }
+
+.food-page .signal-footer > .signal-shell {
+  display: flex;
+  justify-content: space-between;
+  gap: 2rem;
+  padding-block: 2.5rem;
+  color: var(--muted);
+  font-size: .75rem;
+}
+
+.food-page .signal-footer strong { color: var(--ink); }
+.food-page .signal-footer strong span { color: var(--food); }
+.food-page .signal-footer p { margin: 0; }
+.footer-links { display: flex; gap: 1.2rem; }
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.has-reveal .reveal {
+  opacity: 0;
+  transform: translateY(24px);
+  transition: opacity 650ms ease, transform 650ms ease;
+}
+
+.has-reveal .reveal.is-visible {
+  opacity: 1;
+  transform: none;
+}
+
+.food-page body {
+  background:
+    radial-gradient(circle at 83% 11%, rgba(184, 242, 109, 0.055), transparent 22rem),
+    #050505;
+}
+
+.food-hero::before {
+  background: radial-gradient(circle at center, rgba(184, 242, 109, 0.09), transparent 68%);
+}
+
+.food-hero .hero-copy h1 em,
+.food-page .chapter-kicker,
+.food-page .chart-eyebrow {
+  color: var(--food);
+}
+
+.food-active {
+  border-color: var(--food) !important;
+  background: var(--food-soft) !important;
+  color: var(--food) !important;
+}
+
+.food-dot {
+  background: var(--food);
+  box-shadow: 0 0 0 6px rgba(184, 242, 109, 0.09), 0 0 22px rgba(184, 242, 109, 0.44);
+}
+
+.food-verdict {
+  border-color: rgba(184, 242, 109, 0.2);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 26px 90px rgba(0, 0, 0, 0.28);
+}
+
+.life-counter {
+  display: grid;
+  grid-template-columns: 1.65fr 0.75fr;
+  gap: 1px;
+  margin: 2.25rem 0 1rem;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--line);
+}
+
+.life-counter > div {
+  min-height: 13rem;
+  padding: clamp(1.4rem, 3vw, 2.4rem);
+  background:
+    radial-gradient(circle at 90% 0, rgba(255, 116, 94, 0.09), transparent 52%),
+    var(--panel);
+}
+
+.life-counter > div:first-child {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+}
+
+.life-counter .counter-label,
+.counter-minute > span {
+  color: var(--muted);
+  font-size: 0.72rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.life-counter strong {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: clamp(2.7rem, 7vw, 6.2rem);
+  font-weight: 500;
+  letter-spacing: -0.075em;
+  line-height: 0.92;
+}
+
+.life-counter > div:first-child > span:last-child {
+  color: var(--coral);
+  font-size: 0.85rem;
+  letter-spacing: 0.04em;
+}
+
+.counter-minute {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  border-left: 1px solid var(--line);
+}
+
+.counter-minute strong {
+  margin: 1rem 0 0.65rem;
+  color: var(--food);
+  font-size: clamp(2rem, 4vw, 3.7rem);
+}
+
+.species-chart,
+.footprint-chart {
+  display: grid;
+  gap: 0.85rem;
+  min-height: 19rem;
+  padding: 2rem 0 1rem;
+}
+
+.species-row,
+.footprint-row {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr) 5rem;
+  align-items: center;
+  gap: 0.85rem;
+}
+
+.species-name,
+.footprint-name {
+  overflow: hidden;
+  color: var(--ink-soft);
+  font-size: 0.78rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.species-track,
+.footprint-track {
+  position: relative;
+  height: 0.62rem;
+  overflow: hidden;
+  border-radius: 99px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.species-bar,
+.footprint-bar {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: var(--bar-width);
+  min-width: 2px;
+  border-radius: inherit;
+  background: linear-gradient(90deg, var(--coral), #ffb06c);
+  box-shadow: 0 0 20px rgba(255, 116, 94, 0.15);
+  animation: bar-in 700ms cubic-bezier(0.2, 0.8, 0.2, 1) both;
+  animation-delay: var(--bar-delay);
+  transform-origin: left center;
+}
+
+.species-row strong,
+.footprint-row strong {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  font-weight: 500;
+  text-align: right;
+}
+
+.fish-estimate-grid,
+.climate-number-grid,
+.forest-grid,
+.water-grid,
+.health-evidence-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+  margin: 1rem 0;
+}
+
+.estimate-card,
+.big-number-card,
+.forest-card,
+.water-stat,
+.health-card {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(1.35rem, 3vw, 2rem);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--panel);
+}
+
+.estimate-card > strong {
+  display: block;
+  margin: 1rem 0;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  font-weight: 500;
+  letter-spacing: -0.055em;
+}
+
+.estimate-card > strong small {
+  color: var(--muted);
+  font-size: 0.7rem;
+  letter-spacing: 0;
+}
+
+.estimate-card > p:last-child,
+.forest-card p,
+.water-stat span,
+.health-card p,
+.nutrition-balance p {
+  color: var(--ink-soft);
+  line-height: 1.65;
+}
+
+.range-line {
+  height: 3px;
+  margin-bottom: 1.2rem;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.range-line span {
+  display: block;
+  height: 100%;
+  margin-left: 20%;
+  background: var(--food);
+  box-shadow: 0 0 15px rgba(184, 242, 109, 0.3);
+}
+
+.range-line.wild span {
+  margin-left: 12%;
+  background: var(--water);
+}
+
+.dignity-note,
+.amr-note {
+  margin-top: 1rem;
+  border-color: rgba(255, 116, 94, 0.2);
+  background: linear-gradient(135deg, rgba(255, 116, 94, 0.07), transparent 52%), var(--panel);
+}
+
+.dignity-note .boundary-icon,
+.amr-note .boundary-icon {
+  color: var(--coral);
+}
+
+.climate-number-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 2rem;
+}
+
+.big-number-card p,
+.water-stat > p {
+  min-height: 2.3rem;
+  color: var(--muted);
+  font-size: 0.69rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.big-number-card strong,
+.water-stat strong {
+  display: block;
+  margin: 1.5rem 0 0.65rem;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: clamp(2rem, 4.8vw, 4.2rem);
+  font-weight: 500;
+  letter-spacing: -0.065em;
+  line-height: 0.9;
+}
+
+.big-number-card strong small {
+  color: var(--muted);
+  font-size: 0.65rem;
+  letter-spacing: 0;
+}
+
+.big-number-card > span {
+  color: var(--muted);
+  font-size: 0.72rem;
+}
+
+.coral-card {
+  border-color: rgba(255, 116, 94, 0.22);
+  background: linear-gradient(140deg, rgba(255, 116, 94, 0.1), transparent 58%), var(--panel);
+}
+
+.footprint-row {
+  grid-template-columns: 8rem minmax(0, 1fr) 3.5rem;
+}
+
+.footprint-bar {
+  background: linear-gradient(90deg, var(--coral), #ffd078);
+}
+
+.plant-row .footprint-bar {
+  background: linear-gradient(90deg, #7dcf74, var(--food));
+  box-shadow: 0 0 20px rgba(184, 242, 109, 0.12);
+}
+
+.food-good {
+  color: var(--food) !important;
+  background: var(--food-soft) !important;
+}
+
+.resource-comparison {
+  display: grid;
+  gap: 1.65rem;
+  padding: 2rem 0 1rem;
+}
+
+.resource-row {
+  display: grid;
+  grid-template-columns: 7rem minmax(0, 1fr) 8rem;
+  align-items: center;
+  gap: 1rem;
+}
+
+.resource-label {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.resource-label strong {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 1.2rem;
+  font-weight: 500;
+}
+
+.resource-label span,
+.resource-note {
+  color: var(--muted);
+  font-size: 0.68rem;
+}
+
+.resource-track {
+  height: 1.15rem;
+  overflow: hidden;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.resource-fill {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--coral);
+}
+
+.protein-fill { background: var(--food); }
+.calorie-fill { background: #f7b500; }
+
+.land-scenario {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: center;
+  margin: 1rem 0;
+  padding: clamp(1.5rem, 4vw, 2.75rem);
+  border: 1px solid rgba(184, 242, 109, 0.2);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(184, 242, 109, 0.08), transparent 50%), var(--panel);
+}
+
+.scenario-copy h3 {
+  margin: 0.6rem 0 0.7rem;
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: clamp(1.5rem, 3vw, 2.25rem);
+  font-weight: 400;
+}
+
+.scenario-copy > p:last-child {
+  color: var(--ink-soft);
+  line-height: 1.7;
+}
+
+.scenario-visual {
+  display: grid;
+  grid-template-columns: 1fr 3rem 0.58fr;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.scenario-visual svg {
+  width: 100%;
+  fill: none;
+  stroke: var(--muted);
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.5;
+}
+
+.land-block {
+  display: flex;
+  aspect-ratio: 1.15;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid var(--line-strong);
+  border-radius: 5px;
+  background: rgba(255, 255, 255, 0.035);
+}
+
+.land-block span {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: clamp(1.2rem, 3vw, 2rem);
+}
+
+.land-block small {
+  margin-top: 0.35rem;
+  color: var(--muted);
+  font-size: 0.61rem;
+  text-transform: uppercase;
+}
+
+.land-block.plant {
+  border-color: rgba(184, 242, 109, 0.28);
+  background: var(--food-soft);
+}
+
+.forest-card {
+  display: grid;
+  grid-template-columns: 5.2rem 1fr;
+  column-gap: 1rem;
+  align-items: center;
+}
+
+.ring-stat {
+  display: grid;
+  width: 5rem;
+  aspect-ratio: 1;
+  grid-row: 1 / span 2;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(var(--coral) calc(var(--ring-value) * 1%), rgba(255,255,255,0.07) 0);
+}
+
+.ring-stat::before {
+  width: 3.65rem;
+  aspect-ratio: 1;
+  grid-area: 1 / 1;
+  border-radius: 50%;
+  background: var(--panel);
+  content: '';
+}
+
+.ring-stat span {
+  z-index: 1;
+  grid-area: 1 / 1;
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 1rem;
+}
+
+.forest-card h3 {
+  align-self: end;
+  margin: 0 0 0.25rem;
+  color: var(--ink);
+  font-size: 0.95rem;
+}
+
+.forest-card p {
+  align-self: start;
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.soy-card .ring-stat {
+  background: conic-gradient(var(--food) calc(var(--ring-value) * 1%), rgba(255,255,255,0.07) 0);
+}
+
+.precision-line {
+  margin: 0.5rem 0 0;
+  padding: 1rem 1.2rem;
+  border-left: 2px solid var(--muted);
+  color: var(--muted);
+  font-size: 0.76rem;
+  line-height: 1.6;
+}
+
+.water-stat {
+  min-height: 18rem;
+  isolation: isolate;
+}
+
+.water-stat > *:not(.water-wave) {
+  position: relative;
+  z-index: 1;
+}
+
+.water-stat strong {
+  color: var(--water);
+  font-size: clamp(3rem, 7vw, 6rem);
+}
+
+.water-wave {
+  position: absolute;
+  z-index: 0;
+  inset: auto -15% -34% -15%;
+  height: 80%;
+  border-radius: 45% 52% 0 0;
+  background: rgba(88, 199, 237, 0.08);
+  transform: rotate(-4deg);
+}
+
+.pollution-card strong { color: var(--food); }
+.pollution-card .water-wave { background: rgba(184, 242, 109, 0.07); transform: rotate(4deg); }
+
+.scope-ledger {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1px;
+  overflow: hidden;
+  margin-top: 1rem;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-md);
+  background: var(--line);
+}
+
+.scope-ledger > div {
+  display: grid;
+  grid-template-columns: 2rem 1fr;
+  gap: 0.8rem;
+  padding: 1.4rem;
+  background: var(--panel);
+}
+
+.scope-ledger p {
+  margin: 0;
+  color: var(--ink-soft);
+  font-size: 0.82rem;
+  line-height: 1.6;
+}
+
+.scope-mark {
+  display: grid;
+  width: 1.7rem;
+  height: 1.7rem;
+  place-items: center;
+  border-radius: 50%;
+  font-family: var(--mono);
+  font-size: 0.75rem;
+}
+
+.scope-mark.yes { color: var(--food); background: var(--food-soft); }
+.scope-mark.no { color: var(--coral); background: var(--coral-soft); }
+
+.ocean-grid {
+  display: grid;
+  grid-template-columns: 0.75fr 1.25fr;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.ocean-donut-card,
+.ocean-production {
+  margin: 0;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+}
+
+.ocean-donut {
+  display: grid;
+  width: min(100%, 15rem);
+  margin: 0 auto 1.5rem;
+  aspect-ratio: 1;
+  place-items: center;
+  border-radius: 50%;
+  background: conic-gradient(var(--coral) 0 37.7%, var(--water) 37.7% 100%);
+}
+
+.ocean-donut::before {
+  width: 72%;
+  aspect-ratio: 1;
+  grid-area: 1 / 1;
+  border-radius: 50%;
+  background: var(--panel);
+  content: '';
+}
+
+.ocean-donut > div {
+  z-index: 1;
+  display: grid;
+  grid-area: 1 / 1;
+  text-align: center;
+}
+
+.ocean-donut strong {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: clamp(2rem, 4vw, 3.4rem);
+  font-weight: 500;
+}
+
+.ocean-donut span {
+  color: var(--muted);
+  font-size: 0.67rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.ocean-donut-card figcaption,
+.ocean-production > p:last-child {
+  color: var(--muted);
+  font-size: 0.73rem;
+  line-height: 1.6;
+}
+
+.production-row {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.7rem;
+  margin: 2rem 0;
+}
+
+.production-row > span {
+  color: var(--ink-soft);
+  font-size: 0.8rem;
+}
+
+.production-row strong {
+  color: var(--ink);
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+
+.production-track {
+  grid-column: 1 / -1;
+  height: 0.7rem;
+  overflow: hidden;
+  border-radius: 99px;
+  background: rgba(255,255,255,0.06);
+}
+
+.production-track span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--water);
+}
+
+.aqua .production-track span { background: var(--food); }
+
+.health-card {
+  min-height: 22rem;
+}
+
+.classification {
+  display: inline-block;
+  margin: 1.5rem 0 1rem;
+  padding: 0.28rem 0.58rem;
+  border: 1px solid rgba(255, 116, 94, 0.28);
+  border-radius: 99px;
+  color: var(--coral);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+}
+
+.health-card h3 {
+  margin: 0 0 1rem;
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: 1.8rem;
+  font-weight: 400;
+}
+
+.health-card small {
+  display: block;
+  margin-top: 1.5rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--line);
+  color: var(--muted);
+  font-size: 0.69rem;
+  line-height: 1.6;
+}
+
+.evidence-limited .classification {
+  border-color: rgba(247, 181, 0, 0.3);
+  color: var(--amber);
+}
+
+.nutrition-balance {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 2rem;
+  align-items: center;
+  margin: 1rem 0;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid rgba(184, 242, 109, 0.18);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(184, 242, 109, 0.07), transparent 60%), var(--panel);
+}
+
+.nutrition-balance h3 {
+  margin: 0.6rem 0;
+  color: var(--ink);
+  font-family: var(--serif);
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  font-weight: 400;
+}
+
+.nutrient-cloud {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  justify-content: center;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.nutrient-cloud li {
+  padding: 0.65rem 0.9rem;
+  border: 1px solid var(--line-strong);
+  border-radius: 99px;
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.7rem;
+}
+
+.food-conclusion {
+  border-color: rgba(184, 242, 109, 0.24);
+  background: linear-gradient(135deg, rgba(184, 242, 109, 0.1), transparent 48%), var(--panel);
+}
+
+.food-conclusion > span { color: var(--food); }
+
+.food-answer-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.answer-mark.strong { color: var(--food); background: var(--food-soft); }
+.answer-mark.partial { color: var(--amber); background: var(--amber-soft); }
+.answer-mark.open { color: var(--coral); background: var(--coral-soft); }
+
+.action-ladder {
+  margin-top: 1rem;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  border: 1px solid var(--line);
+  border-radius: var(--radius-lg);
+  background: var(--panel);
+}
+
+.action-ladder ol {
+  display: grid;
+  gap: 0;
+  margin: 1.2rem 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.action-ladder li {
+  display: grid;
+  grid-template-columns: 2.5rem 1fr;
+  gap: 1rem;
+  padding: 1.2rem 0;
+  border-top: 1px solid var(--line);
+}
+
+.action-ladder li > span {
+  color: var(--food);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+}
+
+.action-ladder strong { color: var(--ink); font-size: 0.9rem; }
+.action-ladder p { margin: 0.25rem 0 0; color: var(--muted); font-size: 0.78rem; line-height: 1.55; }
+
+@keyframes bar-in {
+  from { opacity: 0.2; transform: scaleX(0); }
+  to { opacity: 1; transform: scaleX(1); }
+}
+
+@media (max-width: 880px) {
+  .life-counter,
+  .land-scenario,
+  .nutrition-balance,
+  .ocean-grid { grid-template-columns: 1fr; }
+  .counter-minute { border-top: 1px solid var(--line); border-left: 0; }
+  .climate-number-grid { grid-template-columns: 1fr 1fr; }
+  .climate-number-grid .big-number-card:first-child { grid-column: 1 / -1; }
+  .food-answer-grid { grid-template-columns: 1fr; }
+  .scenario-visual { max-width: 32rem; }
+}
+
+@media (max-width: 760px) {
+  .food-page .topic-switcher { align-items: flex-start; }
+  .food-page .topic-label { width: 100%; margin-bottom: 0.2rem; }
+  .food-page .topic-pill.future { display: none; }
+  .food-page .future-card { grid-template-columns: 1fr; }
+  .food-page .signal-footer > .signal-shell { align-items: flex-start; flex-direction: column; }
+}
+
+@media (max-width: 640px) {
+  .fish-estimate-grid,
+  .forest-grid,
+  .water-grid,
+  .health-evidence-grid,
+  .scope-ledger,
+  .climate-number-grid { grid-template-columns: 1fr; }
+  .climate-number-grid .big-number-card:first-child { grid-column: auto; }
+  .species-row { grid-template-columns: 4.7rem minmax(0, 1fr) 3.9rem; gap: 0.55rem; }
+  .footprint-row { grid-template-columns: 5.8rem minmax(0, 1fr) 2.8rem; gap: 0.55rem; }
+  .species-name, .footprint-name, .species-row strong, .footprint-row strong { font-size: 0.66rem; }
+  .resource-row { grid-template-columns: 5rem minmax(0, 1fr); gap: 0.7rem; }
+  .resource-note { display: none; }
+  .resource-label { display: grid; }
+  .scenario-visual { grid-template-columns: 1fr 2rem 0.58fr; }
+  .forest-card { grid-template-columns: 4.5rem 1fr; }
+  .ring-stat { width: 4.25rem; }
+  .ring-stat::before { width: 3.1rem; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .species-bar, .footprint-bar { animation: none; }
+}

--- a/ctw.studio/signals/food/food.css
+++ b/ctw.studio/signals/food/food.css
@@ -413,6 +413,8 @@
 .future-card {
   position: relative;
   display: grid;
+  color: inherit;
+  text-decoration: none;
   grid-template-columns: 1fr auto;
   gap: 2rem;
   align-items: center;

--- a/ctw.studio/signals/food/food.js
+++ b/ctw.studio/signals/food/food.js
@@ -1,0 +1,268 @@
+(() => {
+  'use strict';
+
+  const DATA_URL = '../data/food-system.json';
+
+  const compact = new Intl.NumberFormat('en', {
+    notation: 'compact',
+    maximumFractionDigits: 1
+  });
+  const integer = new Intl.NumberFormat('en');
+  const dateFormat = new Intl.DateTimeFormat('en', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+    timeZone: 'UTC'
+  });
+
+  function byId(id) {
+    return document.getElementById(id);
+  }
+
+  function setText(id, value) {
+    const node = byId(id);
+    if (node) node.textContent = value;
+  }
+
+  function safeHttpsUrl(value) {
+    try {
+      const url = new URL(value);
+      return url.protocol === 'https:' ? url.href : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function formatDate(value) {
+    const parsed = new Date(`${value}T00:00:00Z`);
+    return Number.isNaN(parsed.getTime()) ? value : dateFormat.format(parsed);
+  }
+
+  function createTable(headers, rows) {
+    const table = document.createElement('table');
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    headers.forEach((header) => {
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.textContent = header;
+      headRow.append(th);
+    });
+    thead.append(headRow);
+
+    const tbody = document.createElement('tbody');
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      row.forEach((value, index) => {
+        const cell = document.createElement(index === 0 ? 'th' : 'td');
+        if (index === 0) cell.scope = 'row';
+        cell.textContent = value;
+        tr.append(cell);
+      });
+      tbody.append(tr);
+    });
+    table.append(thead, tbody);
+    return table;
+  }
+
+  function renderSpecies(data) {
+    const chart = byId('species-chart');
+    const tableHost = byId('species-table');
+    if (!chart || !tableHost) return;
+    chart.replaceChildren();
+    tableHost.replaceChildren();
+    if (!Array.isArray(data) || !data.length) {
+      chart.textContent = 'No species observations are available.';
+      return;
+    }
+
+    const max = Math.max(...data.map((item) => item.daily));
+    data.forEach((item, index) => {
+      const row = document.createElement('div');
+      row.className = 'species-row';
+
+      const label = document.createElement('span');
+      label.className = 'species-name';
+      label.textContent = item.name;
+
+      const track = document.createElement('div');
+      track.className = 'species-track';
+      const bar = document.createElement('span');
+      bar.className = 'species-bar';
+      bar.style.setProperty('--bar-width', `${(item.daily / max) * 100}%`);
+      bar.style.setProperty('--bar-delay', `${index * 55}ms`);
+      track.append(bar);
+
+      const value = document.createElement('strong');
+      value.textContent = compact.format(item.daily);
+      value.title = integer.format(item.daily);
+
+      row.append(label, track, value);
+      chart.append(row);
+    });
+
+    tableHost.append(createTable(
+      ['Species', 'Annual count', 'Average per day'],
+      data.map((item) => [item.name, integer.format(item.annual), integer.format(item.daily)])
+    ));
+  }
+
+  function renderFootprints(data) {
+    const chart = byId('footprint-chart');
+    const tableHost = byId('footprint-table');
+    if (!chart || !tableHost) return;
+    chart.replaceChildren();
+    tableHost.replaceChildren();
+    if (!Array.isArray(data) || !data.length) {
+      chart.textContent = 'No product-footprint observations are available.';
+      return;
+    }
+
+    const max = Math.max(...data.map((item) => item.kgCO2ePerKgFood));
+    data.forEach((item, index) => {
+      const row = document.createElement('div');
+      row.className = `footprint-row ${index >= data.length - 2 ? 'plant-row' : ''}`;
+
+      const label = document.createElement('span');
+      label.className = 'footprint-name';
+      label.textContent = item.product.replace(' (beef herd)', '');
+
+      const track = document.createElement('div');
+      track.className = 'footprint-track';
+      const bar = document.createElement('span');
+      bar.className = 'footprint-bar';
+      bar.style.setProperty('--bar-width', `${(item.kgCO2ePerKgFood / max) * 100}%`);
+      bar.style.setProperty('--bar-delay', `${index * 55}ms`);
+      track.append(bar);
+
+      const value = document.createElement('strong');
+      value.textContent = item.kgCO2ePerKgFood.toFixed(1);
+
+      row.append(label, track, value);
+      chart.append(row);
+    });
+
+    tableHost.append(createTable(
+      ['Food', 'kg CO₂e per kg food', 'Reference year'],
+      data.map((item) => [item.product, item.kgCO2ePerKgFood.toFixed(2), String(item.year)])
+    ));
+  }
+
+  function renderSources(sources) {
+    const host = byId('food-source-list');
+    if (!host) return;
+    host.replaceChildren();
+
+    sources.forEach((source, index) => {
+      const item = document.createElement('article');
+      item.className = 'source-item';
+
+      const number = document.createElement('span');
+      number.className = 'source-number';
+      number.textContent = String(index + 1).padStart(2, '0');
+
+      const body = document.createElement('div');
+      const title = document.createElement('h3');
+      const sourceUrl = safeHttpsUrl(source.url);
+      const link = document.createElement(sourceUrl ? 'a' : 'span');
+      if (sourceUrl) {
+        link.href = sourceUrl;
+        link.target = '_blank';
+        link.rel = 'noreferrer';
+      }
+      link.textContent = sourceUrl ? source.title : `${source.title} — URL unavailable`;
+      if (sourceUrl) {
+        link.append(Object.assign(document.createElement('span'), {
+          className: 'sr-only',
+          textContent: ' (opens in a new tab)'
+        }));
+      }
+      title.append(link);
+
+      const meta = document.createElement('p');
+      meta.className = 'source-meta';
+      meta.textContent = `${source.publisher} · ${source.publicationDate}`;
+
+      const role = document.createElement('p');
+      role.className = 'source-role';
+      role.textContent = source.role;
+
+      const kind = document.createElement('span');
+      kind.className = 'source-kind';
+      kind.textContent = source.kind;
+
+      body.append(title, meta, role, kind);
+      item.append(number, body);
+      host.append(item);
+    });
+  }
+
+  function setupReveal() {
+    const items = document.querySelectorAll('.reveal');
+    if (!('IntersectionObserver' in window) || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      items.forEach((item) => item.classList.add('is-visible'));
+      return;
+    }
+
+    document.documentElement.classList.add('has-reveal');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { rootMargin: '0px 0px -8% 0px', threshold: 0.08 });
+    items.forEach((item) => observer.observe(item));
+  }
+
+  function setupStoryIndex() {
+    const links = new Map(
+      Array.from(document.querySelectorAll('[data-chapter]')).map((link) => [link.dataset.chapter, link])
+    );
+    const sections = document.querySelectorAll('[data-observe-chapter]');
+    if (!links.size || !sections.length || !('IntersectionObserver' in window)) return;
+
+    const observer = new IntersectionObserver((entries) => {
+      const visible = entries
+        .filter((entry) => entry.isIntersecting)
+        .sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+      if (!visible) return;
+      links.forEach((link) => link.classList.remove('active'));
+      links.get(visible.target.id)?.classList.add('active');
+    }, { rootMargin: '-24% 0px -58% 0px', threshold: [0.01, 0.2, 0.5] });
+    sections.forEach((section) => observer.observe(section));
+  }
+
+  function showDataError(error) {
+    console.error('Could not load the food-system data:', error);
+    document.querySelectorAll('.loading-message').forEach((node) => {
+      node.textContent = 'The baked data could not be loaded. Source links remain available in the page markup and repository data file.';
+    });
+  }
+
+  async function init() {
+    setupReveal();
+    setupStoryIndex();
+
+    try {
+      const response = await fetch(DATA_URL, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+
+      setText('food-data-date', formatDate(data.meta.dataUpdated));
+      setText('slaughter-year', data.slaughter.year);
+      setText('hero-land-daily', compact.format(data.slaughter.dailyTracked));
+      setText('daily-land-exact', integer.format(data.slaughter.dailyTracked));
+      setText('per-minute-exact', integer.format(data.slaughter.perMinuteTracked));
+
+      renderSpecies(data.slaughter.species);
+      renderFootprints(data.productFootprints);
+      renderSources(data.sources);
+    } catch (error) {
+      showDataError(error);
+    }
+  }
+
+  init();
+})();

--- a/ctw.studio/signals/food/index.html
+++ b/ctw.studio/signals/food/index.html
@@ -1,0 +1,477 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth food-page" style="background: #050505">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>What does eating animals cost? — CTW Signals</title>
+  <meta name="description" content="A Factfulness-style dashboard on animal farming: slaughter, fish, emissions, land, forests, water, oceans and health—built from FAO, WHO and peer-reviewed evidence.">
+  <meta name="theme-color" content="#050505">
+  <link rel="canonical" href="https://ctw.studio/signals/food/">
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="What does eating animals cost? — CTW Signals">
+  <meta property="og:description" content="Count the animals. Trace the land, climate, water and health effects. Keep the uncertainty visible.">
+  <meta property="og:url" content="https://ctw.studio/signals/food/">
+  <meta property="og:image" content="https://ctw.studio/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" type="image/png" href="../../favicon.png">
+  <link rel="apple-touch-icon" href="../../favicon.png">
+  <link href="../../tailwind.css" rel="stylesheet">
+  <link href="../signals.css" rel="stylesheet">
+  <link href="food.css" rel="stylesheet">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap"></noscript>
+  <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
+  <script defer src="food.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to the evidence</a>
+  <div id="site-nav"></div>
+
+  <main id="main-content">
+    <section class="signal-hero food-hero" aria-labelledby="page-title">
+      <div class="signal-shell">
+        <div class="topic-switcher" aria-label="Signal topics">
+          <span class="topic-label">Signals /</span>
+          <a class="topic-pill" href="../">AI &amp; work</a>
+          <a class="topic-pill active food-active" href="./" aria-current="page">Food, animals &amp; planet</a>
+          <span class="topic-pill future">Housing <small>queued</small></span>
+        </div>
+
+        <div class="hero-grid">
+          <div class="hero-copy reveal">
+            <p class="brief-id"><span>Brief 002</span><span class="brief-line"></span><span>Global food system</span></p>
+            <h1 id="page-title">What does eating animals cost—<em>beyond the price tag?</em></h1>
+            <p class="hero-deck">Count the lives. Trace the land, emissions, forests, water and health effects. Keep the system boundaries—and the uncertainty—visible.</p>
+            <div class="hero-meta">
+              <span>Data checked <strong id="food-data-date">—</strong></span>
+              <span>Global unless labelled</span>
+              <span>No advocacy math</span>
+            </div>
+          </div>
+
+          <aside class="verdict-card food-verdict reveal" aria-label="Current evidence summary">
+            <div class="verdict-topline">
+              <span class="status-dot food-dot" aria-hidden="true"></span>
+              <span>Current read</span>
+            </div>
+            <p class="verdict-answer">The scale is enormous. The burden is uneven.</p>
+            <p class="verdict-copy">Animal-sourced food is a major driver of land use, livestock emissions and animal deaths. Beef carries an especially large climate and forest footprint. Not every agriculture-wide harm, however, can honestly be assigned to livestock alone.</p>
+            <dl class="verdict-metrics">
+              <div>
+                <dt>Tracked land animals / day</dt>
+                <dd id="hero-land-daily">—</dd>
+              </div>
+              <div>
+                <dt>Livestock share of human GHG</dt>
+                <dd>≈12%</dd>
+              </div>
+              <div>
+                <dt>Farmland for animal foods</dt>
+                <dd>≈83%</dd>
+              </div>
+            </dl>
+            <p class="verdict-footnote">Different years and methods. These figures belong beside one another—not added together.</p>
+          </aside>
+        </div>
+
+        <a class="scroll-cue" href="#story" aria-label="Start the story">
+          <span>Follow the evidence</span>
+          <svg viewBox="0 0 20 20" aria-hidden="true"><path d="M10 3v12m0 0 5-5m-5 5-5-5"/></svg>
+        </a>
+      </div>
+    </section>
+
+    <section id="story" class="signal-story">
+      <div class="signal-shell story-layout">
+        <aside class="story-index" aria-label="Story chapters">
+          <p>The evidence</p>
+          <nav>
+            <a href="#lives" data-chapter="lives"><span>01</span> Lives</a>
+            <a href="#climate" data-chapter="climate"><span>02</span> Climate</a>
+            <a href="#land" data-chapter="land"><span>03</span> Land &amp; forests</a>
+            <a href="#water" data-chapter="water"><span>04</span> Water</a>
+            <a href="#oceans" data-chapter="oceans"><span>05</span> Oceans</a>
+            <a href="#health" data-chapter="health"><span>06</span> Health</a>
+            <a href="#answer" data-chapter="answer"><span>07</span> Answer</a>
+            <a href="#sources" data-chapter="sources"><span>08</span> Sources</a>
+          </nav>
+        </aside>
+
+        <article class="story-content">
+          <section id="lives" class="story-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>01</span> Scale before opinion</p>
+              <h2>How many animals are killed for food every day?</h2>
+              <p>Official global data can answer this for major land animals. For fish, it mostly records tonnes—so researchers must estimate individual lives from body weights.</p>
+            </header>
+
+            <div class="life-counter" aria-label="Latest tracked land animal slaughter total">
+              <div>
+                <span class="counter-label">Seven tracked land species · <span id="slaughter-year">—</span></span>
+                <strong id="daily-land-exact">—</strong>
+                <span>animals per average day</span>
+              </div>
+              <div class="counter-minute">
+                <span>That is about</span>
+                <strong id="per-minute-exact">—</strong>
+                <span>every minute</span>
+              </div>
+            </div>
+
+            <figure class="chart-card species-card">
+              <div class="chart-head">
+                <div>
+                  <p class="chart-eyebrow">Observed · FAO / OWID</p>
+                  <h3>Daily slaughter, by species</h3>
+                </div>
+                <span class="scope-chip">World</span>
+              </div>
+              <div id="species-chart" class="species-chart" role="img" aria-label="Horizontal bars comparing the average daily slaughter count of seven land-animal species"></div>
+              <figcaption>Bars use a common linear scale. Counts divide the annual total by the number of days in the source year. Fish and species absent from the selected series are excluded.</figcaption>
+              <details class="chart-table-wrap">
+                <summary>View the values as a table</summary>
+                <div id="species-table" class="chart-table-scroll"></div>
+              </details>
+            </figure>
+
+            <div class="fish-estimate-grid">
+              <article class="estimate-card">
+                <p class="chart-eyebrow">Estimated · farmed finfish · 2019</p>
+                <strong>≈340M <small>/ day</small></strong>
+                <div class="range-line"><span style="width:46%"></span></div>
+                <p>Peer-reviewed midpoint: 124B a year. Plausible range: <strong>214–468M/day</strong>.</p>
+              </article>
+              <article class="estimate-card">
+                <p class="chart-eyebrow">Estimated · wild finfish · 2019</p>
+                <strong>2.7–5.2B <small>/ day</small></strong>
+                <div class="range-line wild"><span style="width:72%"></span></div>
+                <p>Converted from catch tonnage and estimated body weights. This is a range, not a census.</p>
+              </article>
+            </div>
+
+            <aside class="boundary-note dignity-note">
+              <div class="boundary-icon" aria-hidden="true">≠</div>
+              <div>
+                <h3>A dashboard can count bodies. It cannot count dignity.</h3>
+                <p>There is no standardized global time series for “factory-farmed animals” or humane treatment. Stocking density, cage or outdoor access, premature mortality, transport time and stunning compliance are the kinds of measures that would be needed. Definitions and reporting still differ sharply by country.</p>
+              </div>
+            </aside>
+          </section>
+
+          <section id="climate" class="story-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>02</span> Climate footprint</p>
+              <h2>Livestock is a material climate sector—not the whole climate problem.</h2>
+              <p>FAO estimates livestock agrifood systems emitted 6.2 gigatonnes of CO₂-equivalent in 2015, about 12% of human-caused greenhouse-gas emissions.</p>
+            </header>
+
+            <div class="climate-number-grid">
+              <article class="big-number-card coral-card">
+                <p>Livestock-system emissions</p>
+                <strong>6.2 <small>Gt CO₂e</small></strong>
+                <span>2015 baseline</span>
+              </article>
+              <article class="big-number-card">
+                <p>Share of all anthropogenic GHG</p>
+                <strong>≈12%</strong>
+                <span>FAO scope</span>
+              </article>
+              <article class="big-number-card">
+                <p>Share of agrifood emissions</p>
+                <strong>≈40%</strong>
+                <span>FAO scope</span>
+              </article>
+            </div>
+
+            <figure class="chart-card footprint-card">
+              <div class="chart-head">
+                <div>
+                  <p class="chart-eyebrow">Global meta-analysis · full supply chain</p>
+                  <h3>Not all proteins carry the same footprint</h3>
+                </div>
+                <span class="scope-chip">kg CO₂e / kg food</span>
+              </div>
+              <div id="footprint-chart" class="footprint-chart" role="img" aria-label="Bars comparing greenhouse-gas emissions per kilogram of several foods"></div>
+              <figcaption>Global mean life-cycle estimates from Poore &amp; Nemecek’s dataset. Producer-to-producer variation can be large; product averages describe systems, not every farm.</figcaption>
+              <details class="chart-table-wrap">
+                <summary>View the values as a table</summary>
+                <div id="footprint-table" class="chart-table-scroll"></div>
+              </details>
+            </figure>
+
+            <div class="interpretation-row">
+              <div class="interpretation-icon food-good" aria-hidden="true">↓</div>
+              <div>
+                <strong>What changes the total most?</strong>
+                <p>Diet composition matters more than food miles for many products. Replacing ruminant meat usually produces the largest climate reduction; improving farms also matters, but even low-impact animal products often exceed plant substitutes in this global dataset.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="land" class="story-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>03</span> Land &amp; forests</p>
+              <h2>The land equation is the clearest imbalance.</h2>
+              <p>Animal-sourced foods use most agricultural land while delivering a minority of calories. Pasture expansion for beef is also the largest single driver in the cited tropical-deforestation attribution.</p>
+            </header>
+
+            <figure class="chart-card land-card">
+              <div class="chart-head">
+                <div>
+                  <p class="chart-eyebrow">Poore–Nemecek global food-system estimate</p>
+                  <h3>Share of input versus output</h3>
+                </div>
+                <span class="scope-chip">World · around 2010</span>
+              </div>
+              <div class="resource-comparison">
+                <div class="resource-row">
+                  <div class="resource-label"><strong>83%</strong><span>agricultural land</span></div>
+                  <div class="resource-track"><span class="resource-fill land-fill" style="width:83%"></span></div>
+                  <span class="resource-note">animal-sourced foods</span>
+                </div>
+                <div class="resource-row">
+                  <div class="resource-label"><strong>37%</strong><span>protein</span></div>
+                  <div class="resource-track"><span class="resource-fill protein-fill" style="width:37%"></span></div>
+                  <span class="resource-note">provided</span>
+                </div>
+                <div class="resource-row">
+                  <div class="resource-label"><strong>18%</strong><span>calories</span></div>
+                  <div class="resource-track"><span class="resource-fill calorie-fill" style="width:18%"></span></div>
+                  <span class="resource-note">provided</span>
+                </div>
+              </div>
+              <figcaption>“Animal-sourced foods” includes pasture plus cropland used for feed. Land quality differs; not all grazing land could grow crops. The ratio still captures the opportunity cost for habitat and carbon storage.</figcaption>
+            </figure>
+
+            <div class="land-scenario">
+              <div class="scenario-copy">
+                <p class="chart-eyebrow">Scenario, not forecast</p>
+                <h3>If the world used a plant-based food system</h3>
+                <p>The modelled agricultural footprint falls from <strong>4.1B hectares</strong> to about <strong>1.0B</strong>—a 75% reduction. It includes less pasture and less feed cropland, while direct human-food cropland grows.</p>
+              </div>
+              <div class="scenario-visual" aria-label="Agricultural land falls from 4.1 to 1 billion hectares in a modelled plant-based scenario">
+                <div class="land-block current"><span>4.1B ha</span><small>current mix</small></div>
+                <svg viewBox="0 0 64 24" aria-hidden="true"><path d="M2 12h55m0 0-8-8m8 8-8 8"/></svg>
+                <div class="land-block plant"><span>1.0B ha</span><small>plant-based</small></div>
+              </div>
+            </div>
+
+            <div class="forest-grid">
+              <article class="forest-card">
+                <div class="ring-stat" style="--ring-value:41"><span>41%</span></div>
+                <h3>of tropical deforestation</h3>
+                <p>was attributed to pasture expansion for beef in the 2005–2013 study average—about 2.1M hectares per year.</p>
+              </article>
+              <article class="forest-card soy-card">
+                <div class="ring-stat" style="--ring-value:77"><span>77%</span></div>
+                <h3>of global soy</h3>
+                <p>was fed to livestock in the cited 2018 end-use analysis; about 7% went directly to human foods such as tofu and soy milk.</p>
+              </article>
+            </div>
+            <p class="precision-line"><strong>Boundary:</strong> 41% is not “all global forest loss today.” It is a commodity-attribution result for tropical deforestation in a defined historical study period.</p>
+          </section>
+
+          <section id="water" class="story-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>04</span> Freshwater &amp; nutrient pollution</p>
+              <h2>Agriculture dominates the pressure. Attribution within agriculture is harder.</h2>
+              <p>Irrigation, livestock and aquaculture share an interconnected system. Two large global numbers reveal the scale—but neither is a livestock-only share.</p>
+            </header>
+
+            <div class="water-grid">
+              <article class="water-stat withdrawal-card">
+                <div class="water-wave" aria-hidden="true"></div>
+                <p>Global freshwater withdrawals</p>
+                <strong>69%</strong>
+                <span>agriculture, including irrigation, livestock and aquaculture</span>
+              </article>
+              <article class="water-stat pollution-card">
+                <div class="water-wave" aria-hidden="true"></div>
+                <p>Ocean &amp; freshwater eutrophication</p>
+                <strong>78%</strong>
+                <span>caused by agriculture in the cited food-system assessment</span>
+              </article>
+            </div>
+
+            <div class="scope-ledger">
+              <div>
+                <span class="scope-mark yes">✓</span>
+                <p><strong>We can say:</strong> feed production, fertilizer and manure release nitrogen and phosphorus; agriculture is the dominant global system boundary for eutrophication.</p>
+              </div>
+              <div>
+                <span class="scope-mark no">×</span>
+                <p><strong>We cannot say:</strong> livestock alone causes 69% of withdrawals or 78% of eutrophication. These sources do not make that allocation.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="oceans" class="story-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>05</span> Oceans</p>
+              <h2>More than a third of assessed marine stocks are overfished.</h2>
+              <p>The state of fish populations and the number of fish killed are different questions. FAO measures the former by stocks and production tonnes; researchers estimate the latter in individuals.</p>
+            </header>
+
+            <div class="ocean-grid">
+              <figure class="ocean-donut-card">
+                <div class="ocean-donut" aria-label="37.7 percent of assessed marine stocks were fished at biologically unsustainable levels in 2021">
+                  <div><strong>37.7%</strong><span>unsustainable</span></div>
+                </div>
+                <figcaption>Unweighted share of marine stocks monitored by FAO, 2021. The production-weighted sustainability measure is higher because large, well-managed fisheries count more.</figcaption>
+              </figure>
+              <div class="ocean-production">
+                <p class="chart-eyebrow">Aquatic animal production · 2022</p>
+                <div class="production-row">
+                  <span>Capture fisheries</span>
+                  <strong>92.3M tonnes</strong>
+                  <div class="production-track"><span style="width:97.8%"></span></div>
+                </div>
+                <div class="production-row aqua">
+                  <span>Aquaculture</span>
+                  <strong>94.4M tonnes</strong>
+                  <div class="production-track"><span style="width:100%"></span></div>
+                </div>
+                <p>Aquaculture surpassed capture fisheries as the main producer of aquatic animals for the first time. That shifts pressure; it does not remove welfare, feed, pollution or habitat questions.</p>
+              </div>
+            </div>
+          </section>
+
+          <section id="health" class="story-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>06</span> Human health</p>
+              <h2>The health case is about replacement and planning—not a vegan halo.</h2>
+              <p>Processed meat has an established causal link to colorectal cancer. A balanced vegan diet can provide needed nutrients, but “vegan” alone does not mean nutritious.</p>
+            </header>
+
+            <div class="health-evidence-grid">
+              <article class="health-card evidence-strong">
+                <p class="chart-eyebrow">WHO / IARC</p>
+                <span class="classification">Group 1</span>
+                <h3>Processed meat</h3>
+                <p>Carcinogenic to humans. An analysis of ten studies estimated that eating 50g daily was associated with an <strong>18% higher relative risk</strong> of colorectal cancer.</p>
+                <small>Same evidence class does not mean same danger as smoking. Classification measures confidence that it can cause cancer, not risk magnitude.</small>
+              </article>
+              <article class="health-card evidence-limited">
+                <p class="chart-eyebrow">WHO / IARC</p>
+                <span class="classification">Group 2A</span>
+                <h3>Red meat</h3>
+                <p>Probably carcinogenic to humans, based on limited epidemiological evidence plus strong mechanistic evidence.</p>
+                <small>“Limited” means chance, bias or confounding could not be ruled out in the human evidence.</small>
+              </article>
+            </div>
+
+            <div class="nutrition-balance">
+              <div>
+                <p class="chart-eyebrow">NHS guidance</p>
+                <h3>A well-planned vegan diet can meet nutritional needs.</h3>
+                <p>Variety, fortified foods and appropriate supplements matter. Special life stages deserve professional guidance.</p>
+              </div>
+              <ul class="nutrient-cloud" aria-label="Nutrients that need attention in a vegan diet">
+                <li>B12</li><li>Vitamin D</li><li>Iodine</li><li>Iron</li><li>Calcium</li><li>Selenium</li><li>Omega-3</li>
+              </ul>
+            </div>
+
+            <aside class="boundary-note amr-note">
+              <div class="boundary-icon" aria-hidden="true">Rx</div>
+              <div>
+                <h3>Antimicrobial resistance crosses the farm gate.</h3>
+                <p>WHO estimates bacterial AMR was associated with more than 4.7M deaths globally in 2021 and identifies misuse and overuse across humans, animals and plants as drivers. The global death total cannot be assigned wholesale to animal farming from that evidence.</p>
+              </div>
+            </aside>
+          </section>
+
+          <section id="answer" class="story-chapter conclusion-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>07</span> The answer, for now</p>
+              <h2>Does moving away from animal farming materially change the picture?</h2>
+            </header>
+
+            <div class="conclusion-verdict food-conclusion">
+              <span>Yes—especially for animals, land, beef-driven deforestation and food-system emissions.</span>
+              <p>The strongest global evidence supports a shift toward plant-rich diets. It does not support collapsing every environmental or health problem into one livestock statistic, nor pretending all animal foods, farms, places or people are interchangeable.</p>
+            </div>
+
+            <div class="answer-grid food-answer-grid">
+              <article>
+                <span class="answer-mark strong">Strong</span>
+                <h3>Direct evidence</h3>
+                <p>Animal slaughter counts; fish production; livestock emissions; animal-food land use; beef-linked tropical deforestation; processed-meat cancer evidence.</p>
+              </article>
+              <article>
+                <span class="answer-mark partial">Shared</span>
+                <h3>System-level evidence</h3>
+                <p>Freshwater withdrawals, eutrophication and antimicrobial resistance involve animal farming, crop farming and other pathways. Attribution must stay explicit.</p>
+              </article>
+              <article>
+                <span class="answer-mark open">Missing</span>
+                <h3>What data still fails us</h3>
+                <p>Comparable global welfare measures, a true individual fish census, consistent intensive-farm definitions, and timely farm-level pollution reporting.</p>
+              </article>
+            </div>
+
+            <div class="action-ladder">
+              <p class="chart-eyebrow">If the goal is impact rather than identity</p>
+              <ol>
+                <li><span>01</span><div><strong>Reduce ruminant meat first.</strong><p>Beef and lamb dominate many land and climate comparisons.</p></div></li>
+                <li><span>02</span><div><strong>Replace—do not merely remove.</strong><p>Use varied legumes, grains, vegetables, nuts, seeds and fortified foods; plan B12.</p></div></li>
+                <li><span>03</span><div><strong>Count welfare as well as carbon.</strong><p>Switching from cattle to chicken can lower emissions while increasing the number of animals killed.</p></div></li>
+                <li><span>04</span><div><strong>Keep producer variation visible.</strong><p>Better farming practices matter even when global product categories remain far apart.</p></div></li>
+              </ol>
+            </div>
+          </section>
+
+          <section id="sources" class="story-chapter sources-chapter reveal" data-observe-chapter>
+            <header class="chapter-head">
+              <p class="chapter-kicker"><span>08</span> Evidence trail</p>
+              <h2>Every headline number has a boundary.</h2>
+              <p>Primary international statistics and peer-reviewed research take priority. Synthesis pages are used where they expose the underlying study and definition clearly.</p>
+            </header>
+
+            <div class="method-grid">
+              <article><span>01</span><h3>Observe</h3><p>Use FAO counts and assessments for what is directly measured.</p></article>
+              <article><span>02</span><h3>Estimate</h3><p>Label modelled fish counts as ranges, never official totals.</p></article>
+              <article><span>03</span><h3>Attribute</h3><p>Separate livestock-specific evidence from agriculture-wide shares.</p></article>
+              <article><span>04</span><h3>Compare</h3><p>Keep periods, units, denominators and study scopes visible.</p></article>
+            </div>
+
+            <div id="food-source-list" class="source-list" aria-live="polite">
+              <p class="loading-message">Loading the evidence ledger…</p>
+            </div>
+
+            <details class="method-details">
+              <summary>Data and editorial method</summary>
+              <div>
+                <p><strong>Updateable observations.</strong> The land-animal count is the sum of seven major species in the latest World row of the FAO-derived OWID series. The update script also rebuilds the product-footprint comparison from the published Poore–Nemecek dataset.</p>
+                <p><strong>Fish.</strong> FAO reports aquatic animals in tonnes. Individual totals are peer-reviewed estimates that divide production or catch by estimated species/country body weights. They are presented separately because uncertainty is large.</p>
+                <p><strong>Scenarios.</strong> A 75% land reduction under a global plant-based diet is a modelled counterfactual. It is not a prediction of consumer behavior or a date-bound forecast.</p>
+                <p><strong>Health.</strong> Relative risk is not absolute risk. Diet adequacy depends on foods, quantities, fortification, supplements and life stage—not on a label alone.</p>
+                <p><strong>Refresh.</strong> Run <code>python3 signals/scripts/update_food_data.py</code> from <code>ctw.studio</code>, then review the diff, periods and source definitions before publishing.</p>
+              </div>
+            </details>
+          </section>
+
+          <section class="future-card reveal" aria-label="Future Signals topics">
+            <div>
+              <p class="chapter-kicker"><span>Next</span> Expand the lens</p>
+              <h2>Housing: are homes becoming less attainable?</h2>
+              <p>Prices, income, rents, mortgage costs, supply and household formation—without turning one national market into “the world.”</p>
+            </div>
+            <span class="future-tag">Queued</span>
+          </section>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <footer class="signal-footer">
+    <div class="signal-shell">
+      <div><strong>CTW<span>.</span>Signals</strong><p>Evidence before narrative.</p></div>
+      <div class="footer-links"><a href="../../">Studio</a><a href="../">AI &amp; work</a><a href="#sources">Sources</a></div>
+    </div>
+  </footer>
+
+  <noscript><div class="noscript-note">This briefing needs JavaScript to load its baked data and charts. The narrative and source boundaries remain readable above.</div></noscript>
+</body>
+</html>

--- a/ctw.studio/signals/food/index.html
+++ b/ctw.studio/signals/food/index.html
@@ -36,7 +36,8 @@
           <span class="topic-label">Signals /</span>
           <a class="topic-pill" href="../">AI &amp; work</a>
           <a class="topic-pill active food-active" href="./" aria-current="page">Food, animals &amp; planet</a>
-          <span class="topic-pill future">Housing <small>queued</small></span>
+          <a class="topic-pill" href="../housing/">Housing</a>
+          <a class="topic-pill" href="../roadmap/">Roadmap</a>
         </div>
 
         <div class="hero-grid">
@@ -452,14 +453,14 @@
             </details>
           </section>
 
-          <section class="future-card reveal" aria-label="Future Signals topics">
+          <a class="future-card reveal" href="../housing/" aria-label="Read the Housing and affordability Signals briefing">
             <div>
               <p class="chapter-kicker"><span>Next</span> Expand the lens</p>
               <h2>Housing: are homes becoming less attainable?</h2>
               <p>Prices, income, rents, mortgage costs, supply and household formation—without turning one national market into “the world.”</p>
             </div>
-            <span class="future-tag">Queued</span>
-          </section>
+            <span class="future-tag">Read brief →</span>
+          </a>
         </article>
       </div>
     </section>

--- a/ctw.studio/signals/housing/housing.css
+++ b/ctw.studio/signals/housing/housing.css
@@ -1,0 +1,594 @@
+:root {
+  --housing-bg: #070807;
+  --housing-panel: #10120f;
+  --housing-panel-2: #151812;
+  --housing-paper: #f2f0e8;
+  --housing-muted: #9ea397;
+  --housing-faint: #70766c;
+  --housing-line: rgba(242, 240, 232, .13);
+  --housing-line-strong: rgba(242, 240, 232, .25);
+  --housing-gold: #ffb15c;
+  --housing-red: #f16f82;
+  --housing-blue: #79c7ff;
+  --housing-violet: #b9a0ff;
+  --housing-green: #a7d68c;
+  --housing-mono: "DM Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+.housing-page {
+  overflow-x: hidden;
+}
+
+.housing-page,
+.housing-page body {
+  background: var(--housing-bg);
+  color: var(--housing-paper);
+}
+
+.housing-page body {
+  margin: 0;
+  overflow-x: hidden;
+  font-family: Inter, system-ui, sans-serif;
+}
+
+.housing-page body::before {
+  position: fixed;
+  inset: 0;
+  z-index: -2;
+  content: "";
+  pointer-events: none;
+  background:
+    radial-gradient(circle at 78% 10%, rgba(255, 177, 92, .09), transparent 31rem),
+    radial-gradient(circle at 5% 35%, rgba(121, 199, 255, .055), transparent 27rem),
+    linear-gradient(rgba(255,255,255,.018) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,.018) 1px, transparent 1px);
+  background-size: auto, auto, 48px 48px, 48px 48px;
+}
+
+.housing-page * { box-sizing: border-box; }
+.housing-page a { color: inherit; }
+.housing-page button { font: inherit; }
+
+.housing-page .signal-shell {
+  width: min(1180px, calc(100% - 48px));
+  margin-inline: auto;
+}
+
+.housing-hero {
+  position: relative;
+  padding: 118px 0 0;
+  border-bottom: 1px solid var(--housing-line);
+}
+
+.housing-hero::after {
+  position: absolute;
+  right: 0;
+  bottom: -1px;
+  width: 46vw;
+  height: 1px;
+  content: "";
+  background: linear-gradient(90deg, transparent, var(--housing-gold), transparent);
+}
+
+.housing-topics {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  overflow-x: auto;
+  padding: 3px 0 52px;
+  scrollbar-width: none;
+}
+
+.housing-topics::-webkit-scrollbar { display: none; }
+
+.housing-topics .topic-label {
+  flex: 0 0 auto;
+  margin-right: 4px;
+  color: var(--housing-faint);
+  font: 500 11px/1 var(--housing-mono);
+  letter-spacing: .12em;
+  text-transform: uppercase;
+}
+
+.housing-topics .topic-pill {
+  flex: 0 0 auto;
+  padding: 8px 12px;
+  border: 1px solid var(--housing-line);
+  border-radius: 999px;
+  color: var(--housing-muted);
+  font: 500 11px/1 var(--housing-mono);
+  text-decoration: none;
+  transition: border-color .2s ease, color .2s ease, background .2s ease;
+}
+
+.housing-topics .topic-pill:hover,
+.housing-topics .topic-pill:focus-visible {
+  border-color: var(--housing-line-strong);
+  color: var(--housing-paper);
+}
+
+.housing-topics .housing-active {
+  border-color: rgba(255, 177, 92, .5);
+  background: rgba(255, 177, 92, .11);
+  color: var(--housing-gold);
+}
+
+.housing-hero-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(320px, .55fr);
+  gap: clamp(48px, 8vw, 112px);
+  align-items: end;
+  padding-bottom: 76px;
+}
+
+.brief-id {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 0 0 25px;
+  color: var(--housing-gold);
+  font: 500 11px/1 var(--housing-mono);
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+.brief-id .brief-line {
+  width: 46px;
+  height: 1px;
+  background: rgba(255, 177, 92, .55);
+}
+
+.housing-hero-copy h1 {
+  max-width: 830px;
+  margin: 0;
+  color: var(--housing-paper);
+  font-size: clamp(48px, 6.8vw, 94px);
+  font-weight: 700;
+  line-height: .96;
+  letter-spacing: -.065em;
+}
+
+.housing-hero-copy h1 em {
+  color: var(--housing-gold);
+  font-family: Georgia, serif;
+  font-weight: 400;
+}
+
+.housing-deck {
+  max-width: 690px;
+  margin: 32px 0 0;
+  color: #c7c9c1;
+  font-size: clamp(17px, 1.55vw, 21px);
+  line-height: 1.58;
+}
+
+.housing-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 24px;
+  margin-top: 33px;
+  color: var(--housing-faint);
+  font: 400 10px/1.4 var(--housing-mono);
+  letter-spacing: .045em;
+  text-transform: uppercase;
+}
+
+.housing-meta strong { color: var(--housing-muted); font-weight: 500; }
+.housing-meta a { color: var(--housing-gold); text-underline-offset: 4px; }
+
+.housing-verdict {
+  position: relative;
+  padding: 27px;
+  border: 1px solid rgba(255, 177, 92, .28);
+  background: linear-gradient(145deg, rgba(255, 177, 92, .075), rgba(255,255,255,.015));
+}
+
+.housing-verdict::before {
+  position: absolute;
+  top: -1px;
+  left: 26px;
+  width: 65px;
+  height: 2px;
+  content: "";
+  background: var(--housing-gold);
+}
+
+.verdict-label,
+.housing-chart-card .chart-card-head span,
+.mortgage-card > p:first-child,
+.tenure-card > p:first-child,
+.comparison-header span,
+.world-number > span,
+.world-derived > span,
+.source-ledger-head span {
+  margin: 0;
+  color: var(--housing-gold);
+  font: 500 10px/1.3 var(--housing-mono);
+  letter-spacing: .11em;
+  text-transform: uppercase;
+}
+
+.housing-verdict > p:nth-child(2) {
+  margin: 14px 0 20px;
+  color: #e5e4df;
+  font-size: 15px;
+  line-height: 1.55;
+}
+
+.verdict-scale { display: flex; gap: 6px; }
+.verdict-scale span { width: 35px; height: 3px; background: rgba(255,255,255,.12); }
+.verdict-scale .active { background: var(--housing-gold); }
+
+.housing-verdict dl {
+  display: grid;
+  gap: 12px;
+  margin: 24px 0 0;
+  padding-top: 20px;
+  border-top: 1px solid var(--housing-line);
+}
+
+.housing-verdict dl div { display: flex; align-items: baseline; justify-content: space-between; gap: 20px; }
+.housing-verdict dt { color: var(--housing-faint); font: 400 10px/1.3 var(--housing-mono); }
+.housing-verdict dd { margin: 0; color: var(--housing-paper); font: 500 16px/1 var(--housing-mono); }
+
+.question-rail {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  margin: 0;
+  padding: 0;
+  border: solid var(--housing-line);
+  border-width: 1px 1px 0;
+  list-style: none;
+}
+
+.question-rail li {
+  min-width: 0;
+  padding: 16px 18px;
+  border-right: 1px solid var(--housing-line);
+  color: var(--housing-faint);
+  font: 500 10px/1.35 var(--housing-mono);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.question-rail li:last-child { border-right: 0; }
+.question-rail span { margin-right: 6px; color: var(--housing-gold); }
+
+.housing-layout {
+  display: grid;
+  grid-template-columns: minmax(210px, 1fr) minmax(0, 920px) minmax(24px, 1fr);
+  max-width: 1440px;
+  margin-inline: auto;
+}
+
+.housing-index {
+  position: sticky;
+  top: 88px;
+  align-self: start;
+  justify-self: end;
+  width: 210px;
+  margin: 100px 48px 0 0;
+  padding-left: 22px;
+  border-left: 1px solid var(--housing-line);
+}
+
+.housing-index > p {
+  margin: 0 0 18px;
+  color: var(--housing-faint);
+  font: 500 9px/1 var(--housing-mono);
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+
+.housing-index nav { display: grid; gap: 4px; }
+.housing-index nav a {
+  display: flex;
+  gap: 10px;
+  padding: 8px 0;
+  color: var(--housing-faint);
+  font: 400 11px/1.3 var(--housing-mono);
+  text-decoration: none;
+  transition: color .2s ease;
+}
+.housing-index nav a:hover,
+.housing-index nav a.active { color: var(--housing-paper); }
+.housing-index nav a.active span { color: var(--housing-gold); }
+.housing-index nav span { width: 20px; color: #565b53; }
+
+.index-legend {
+  display: grid;
+  gap: 8px;
+  margin-top: 28px;
+  padding-top: 20px;
+  border-top: 1px solid var(--housing-line);
+  color: var(--housing-faint);
+  font: 400 9px/1 var(--housing-mono);
+  text-transform: uppercase;
+}
+.dot { display: inline-block; width: 6px; height: 6px; margin-right: 6px; border-radius: 50%; }
+.world-dot { background: var(--housing-green); }
+.nl-dot { background: var(--housing-gold); }
+.compare-dot { background: var(--housing-blue); }
+
+.housing-story { grid-column: 2; min-width: 0; }
+.housing-chapter { padding: 112px 0; border-bottom: 1px solid var(--housing-line); scroll-margin-top: 70px; }
+.chapter-head { max-width: 780px; margin-bottom: 48px; }
+.chapter-kicker { display: flex; gap: 11px; margin: 0 0 20px; color: var(--housing-muted); font: 500 10px/1 var(--housing-mono); letter-spacing: .1em; text-transform: uppercase; }
+.chapter-kicker span { color: var(--housing-gold); }
+.chapter-head h2 { margin: 0; color: var(--housing-paper); font-size: clamp(34px, 4.6vw, 57px); font-weight: 650; line-height: 1.06; letter-spacing: -.048em; }
+.chapter-head > p:last-child { max-width: 700px; margin: 23px 0 0; color: var(--housing-muted); font-size: 17px; line-height: 1.65; }
+
+.lens-tabs { display: flex; gap: 6px; margin-bottom: 10px; }
+.lens-tabs button {
+  padding: 11px 15px;
+  border: 1px solid var(--housing-line);
+  background: transparent;
+  color: var(--housing-muted);
+  font: 500 10px/1 var(--housing-mono);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+.lens-tabs button:hover,
+.lens-tabs button:focus-visible { border-color: var(--housing-line-strong); color: var(--housing-paper); }
+.lens-tabs button[aria-selected="true"] { border-color: rgba(255, 177, 92, .45); background: rgba(255, 177, 92, .09); color: var(--housing-gold); }
+
+.lens-panel { min-height: 330px; padding: clamp(28px, 5vw, 48px); border: 1px solid var(--housing-line); background: rgba(15,17,14,.8); }
+.lens-panel[hidden] { display: none; }
+#lens-world { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+#lens-world[hidden] { display: none; }
+.world-number,
+.world-derived { padding: 8px 0 25px; border-bottom: 1px solid var(--housing-line); }
+.world-number strong,
+.world-derived strong { display: block; margin: 16px 0 9px; font-size: clamp(52px, 7vw, 78px); line-height: .95; letter-spacing: -.06em; }
+.world-number strong { color: var(--housing-green); }
+.world-derived strong { color: var(--housing-paper); }
+.world-number p,
+.world-derived p { max-width: 340px; margin: 0; color: var(--housing-muted); font-size: 14px; line-height: 1.55; }
+.boundary-note { grid-column: 1 / -1; margin: 8px 0 0; padding: 16px 18px; border-left: 2px solid var(--housing-gold); background: rgba(255,177,92,.045); color: var(--housing-muted); font-size: 13px; line-height: 1.6; }
+.boundary-note strong { color: var(--housing-paper); }
+
+.nl-now-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 1px; background: var(--housing-line); }
+.nl-now-grid article { min-height: 142px; padding: 23px; background: var(--housing-panel); }
+.nl-now-grid span { display: block; color: var(--housing-faint); font: 500 9px/1.3 var(--housing-mono); letter-spacing: .06em; text-transform: uppercase; }
+.nl-now-grid strong { display: block; margin: 18px 0 7px; color: var(--housing-gold); font-size: 34px; letter-spacing: -.04em; }
+.nl-now-grid small { display: block; color: var(--housing-muted); font: 400 9px/1.45 var(--housing-mono); }
+.lens-read { margin: 25px 0 0; color: var(--housing-muted); font-size: 14px; line-height: 1.65; }
+.lens-read strong { color: var(--housing-paper); }
+
+.comparison-header,
+.chart-card-head,
+.source-ledger-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; }
+.comparison-header h3,
+.chart-card-head h3,
+.source-ledger-head h3 { margin: 7px 0 0; font-size: 20px; font-weight: 600; letter-spacing: -.025em; }
+.period-chip { flex: 0 0 auto; padding: 7px 9px; border: 1px solid var(--housing-line); color: var(--housing-muted) !important; font: 500 9px/1 var(--housing-mono) !important; letter-spacing: .06em; }
+.country-comparison { display: grid; gap: 14px; margin-top: 32px; }
+.country-row { display: grid; grid-template-columns: 105px minmax(0, 1fr) 48px; gap: 13px; align-items: center; }
+.country-row > span { color: var(--housing-muted); font: 500 10px/1 var(--housing-mono); }
+.country-row > div { position: relative; height: 8px; background: rgba(255,255,255,.055); }
+.country-row b { display: block; height: 100%; background: var(--housing-blue); }
+.country-row strong { color: var(--housing-paper); font: 500 11px/1 var(--housing-mono); text-align: right; }
+.country-row--primary > span,
+.country-row--primary strong { color: var(--housing-gold); }
+.country-row--primary b { background: var(--housing-gold); }
+.country-baseline { position: absolute; top: -4px; width: 1px; height: 16px; background: rgba(255,255,255,.45); }
+
+.housing-chart-card,
+.overburden-card,
+.tenure-card,
+.mortgage-card,
+.interpret-card { border: 1px solid var(--housing-line); background: rgba(15,17,14,.82); }
+.housing-chart-card { margin: 0; padding: clamp(24px, 4vw, 38px); }
+.housing-legend { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 8px 15px; max-width: 320px; }
+.housing-legend span { display: flex; align-items: center; gap: 6px; color: var(--housing-muted); font: 400 9px/1 var(--housing-mono); }
+.housing-legend i { width: 12px; height: 2px; }
+.housing-line-chart { display: block; width: 100%; height: auto; margin-top: 28px; overflow: visible; }
+.housing-grid-line { stroke: rgba(255,255,255,.08); stroke-width: 1; }
+.housing-axis-label { fill: #747a70; font: 9px var(--housing-mono); }
+.housing-baseline-line { stroke: rgba(255,255,255,.28); stroke-width: 1; stroke-dasharray: 4 5; }
+.housing-baseline-label { fill: #a4a89f; font: 8px var(--housing-mono); text-transform: uppercase; }
+.housing-series { fill: none; stroke-width: 2.4; stroke-linejoin: round; stroke-linecap: round; }
+.housing-series--housePrice { stroke: var(--housing-gold); }
+.housing-series--rentPrice { stroke: var(--housing-blue); }
+.housing-series--priceToIncome { stroke: var(--housing-red); }
+.housing-series--priceToRent { stroke: var(--housing-violet); }
+.housing-dot { stroke: var(--housing-bg); stroke-width: 2; }
+.housing-dot--housePrice { fill: var(--housing-gold); }
+.housing-dot--rentPrice { fill: var(--housing-blue); }
+.housing-dot--priceToIncome { fill: var(--housing-red); }
+.housing-dot--priceToRent { fill: var(--housing-violet); }
+.housing-chart-card figcaption,
+.overburden-card figcaption { margin: 16px 0 0; color: var(--housing-faint); font: 400 10px/1.6 var(--housing-mono); }
+
+.data-table-wrap { margin-top: 20px; padding-top: 15px; border-top: 1px solid var(--housing-line); }
+.data-table-wrap summary,
+.method-details summary { color: var(--housing-muted); font: 500 10px/1.3 var(--housing-mono); cursor: pointer; }
+.data-table-scroll { overflow-x: auto; margin-top: 17px; }
+.data-table-scroll table { width: 100%; border-collapse: collapse; color: var(--housing-muted); font: 400 10px/1.3 var(--housing-mono); }
+.data-table-scroll caption { position: absolute; width: 1px; height: 1px; overflow: hidden; clip: rect(0 0 0 0); }
+.data-table-scroll th,
+.data-table-scroll td { padding: 9px 11px; border-bottom: 1px solid var(--housing-line); text-align: right; white-space: nowrap; }
+.data-table-scroll th:first-child,
+.data-table-scroll td:first-child { text-align: left; }
+.data-table-scroll thead th { color: var(--housing-paper); font-weight: 500; }
+
+.rate-and-price-grid { display: grid; grid-template-columns: .85fr 1.15fr; gap: 12px; margin: 12px 0; }
+.mortgage-card,
+.interpret-card { padding: 29px; }
+.mortgage-card > strong { display: block; margin-top: 20px; color: var(--housing-gold); font-size: 50px; letter-spacing: -.06em; }
+.mortgage-card > span { color: var(--housing-muted); font: 400 10px/1 var(--housing-mono); }
+.rate-track { position: relative; height: 3px; margin: 25px 0 15px; background: linear-gradient(90deg, var(--housing-green), var(--housing-gold), var(--housing-red)); }
+.rate-track i { position: absolute; top: -5px; width: 2px; height: 13px; background: var(--housing-paper); }
+.mortgage-card > p:last-child { margin: 0; color: var(--housing-faint); font: 400 10px/1.55 var(--housing-mono); }
+.interpret-card > p:first-child { margin: 0; color: var(--housing-red); font: 500 10px/1 var(--housing-mono); text-transform: uppercase; }
+.interpret-card h3 { max-width: 430px; margin: 18px 0 14px; font-size: 25px; line-height: 1.15; letter-spacing: -.035em; }
+.interpret-card > p:last-child { margin: 0; color: var(--housing-muted); font-size: 14px; line-height: 1.65; }
+
+.supply-card { margin-top: 12px; }
+.supply-chart { display: grid; grid-template-columns: repeat(7, 1fr); gap: 13px; height: 250px; margin: 32px 0 8px; padding-top: 15px; border-bottom: 1px solid var(--housing-line-strong); }
+.supply-year { display: grid; grid-template-rows: 1fr 20px; min-width: 0; }
+.supply-bars { display: flex; align-items: end; justify-content: center; gap: 5px; min-height: 0; }
+.supply-bar { display: block; width: min(16px, 38%); min-height: 2px; }
+.supply-bar--stock { background: var(--housing-gold); }
+.supply-bar--households { background: var(--housing-blue); }
+.supply-year > span { align-self: end; color: var(--housing-faint); font: 400 9px/1 var(--housing-mono); text-align: center; }
+
+.distribution-grid { display: grid; grid-template-columns: 1.15fr .85fr; gap: 12px; }
+.overburden-card,
+.tenure-card { margin: 0; padding: 30px; }
+.overburden-chart { display: grid; gap: 22px; margin-top: 36px; }
+.overburden-chart > div { display: grid; grid-template-columns: 150px 1fr 52px; gap: 12px; align-items: center; }
+.overburden-chart span { color: var(--housing-muted); font: 400 10px/1.25 var(--housing-mono); }
+.overburden-chart > div > div { height: 9px; background: rgba(255,255,255,.055); }
+.overburden-chart i { display: block; height: 100%; background: linear-gradient(90deg, var(--housing-gold), var(--housing-red)); }
+.overburden-chart strong { color: var(--housing-paper); font: 500 11px/1 var(--housing-mono); text-align: right; }
+.tenure-card h3 { margin: 16px 0 30px; font-size: 23px; line-height: 1.25; letter-spacing: -.03em; }
+.tenure-stack { display: flex; height: 18px; margin-bottom: 23px; overflow: hidden; }
+.tenure-segment { display: block; min-width: 2px; }
+.tenure-segment--own { background: var(--housing-gold); }
+.tenure-segment--rent_mkt { background: var(--housing-red); }
+.tenure-segment--rent_fr { background: var(--housing-blue); }
+.tenure-card dl { display: grid; gap: 9px; margin: 0; }
+.tenure-card dl div { display: flex; justify-content: space-between; gap: 12px; padding-bottom: 9px; border-bottom: 1px solid var(--housing-line); }
+.tenure-card dt { color: var(--housing-muted); font: 400 10px/1 var(--housing-mono); }
+.tenure-card dd { margin: 0; color: var(--housing-paper); font: 500 11px/1 var(--housing-mono); }
+.micro-note { margin: 19px 0 0; color: var(--housing-faint); font: 400 9px/1.6 var(--housing-mono); }
+.distribution-conclusion { display: grid; grid-template-columns: 170px 1fr; gap: 30px; margin: 12px 0 0; padding: 30px; border: 1px solid rgba(241,111,130,.22); background: rgba(241,111,130,.04); }
+.distribution-conclusion span { color: var(--housing-red); font: 500 9px/1.4 var(--housing-mono); letter-spacing: .08em; text-transform: uppercase; }
+.distribution-conclusion p { margin: 0; color: #d5d6d0; font-family: Georgia, serif; font-size: 20px; line-height: 1.48; }
+
+.explanation-grid,
+.possibility-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+.explanation-grid article,
+.possibility-grid article { min-height: 230px; padding: 30px; border: 1px solid var(--housing-line); background: rgba(15,17,14,.7); }
+.explanation-grid article > span,
+.possibility-grid article > span { color: var(--housing-gold); font: 500 10px/1 var(--housing-mono); letter-spacing: .08em; text-transform: uppercase; }
+.explanation-grid h3,
+.possibility-grid h3 { margin: 34px 0 13px; font-size: 23px; letter-spacing: -.03em; }
+.explanation-grid p,
+.possibility-grid p { margin: 0; color: var(--housing-muted); font-size: 14px; line-height: 1.65; }
+.explanation-warning { display: grid; grid-template-columns: 210px 1fr; gap: 35px; margin-top: 12px; padding: 27px 30px; border-left: 2px solid var(--housing-gold); background: rgba(255,177,92,.04); }
+.explanation-warning strong { color: var(--housing-gold); font: 500 10px/1.5 var(--housing-mono); text-transform: uppercase; }
+.explanation-warning p { margin: 0; color: var(--housing-muted); font-size: 13px; line-height: 1.6; }
+
+.change-list { display: grid; gap: 0; margin: 0; padding: 0; border-top: 1px solid var(--housing-line); list-style: none; }
+.change-list li { display: grid; grid-template-columns: 55px 1fr; border-bottom: 1px solid var(--housing-line); }
+.change-list span { padding: 23px 0; color: var(--housing-gold); font: 500 10px/1.5 var(--housing-mono); }
+.change-list p { margin: 0; padding: 21px 0; color: #d3d5ce; font-size: 15px; line-height: 1.55; }
+.current-answer { margin-top: 36px; padding: 30px; border: 1px solid rgba(167,214,140,.25); background: rgba(167,214,140,.045); }
+.current-answer span { color: var(--housing-green); font: 500 9px/1 var(--housing-mono); letter-spacing: .08em; text-transform: uppercase; }
+.current-answer p { max-width: 760px; margin: 17px 0 0; color: var(--housing-paper); font-family: Georgia, serif; font-size: 22px; line-height: 1.45; }
+
+.possibility-chapter { position: relative; }
+.possibility-chapter::before { position: absolute; inset: 50px -60px; z-index: -1; content: ""; background: radial-gradient(circle at 30% 50%, rgba(167,214,140,.05), transparent 58%); }
+.possibility-grid article { border-color: rgba(167,214,140,.18); }
+.possibility-grid article > span { color: var(--housing-green); }
+
+.method-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; background: var(--housing-line); }
+.method-grid article { padding: 24px 20px; background: var(--housing-panel); }
+.method-grid span { color: var(--housing-gold); font: 500 9px/1 var(--housing-mono); }
+.method-grid h3 { margin: 24px 0 10px; font-size: 16px; letter-spacing: -.02em; }
+.method-grid p { margin: 0; color: var(--housing-faint); font-size: 12px; line-height: 1.6; }
+.method-details { margin-top: 12px; padding: 20px 23px; border: 1px solid var(--housing-line); }
+.method-details div { columns: 2; column-gap: 40px; margin-top: 20px; }
+.method-details p { break-inside: avoid; margin: 0 0 14px; color: var(--housing-muted); font-size: 12px; line-height: 1.65; }
+.method-details strong { color: var(--housing-paper); }
+.method-details code { color: var(--housing-gold); font-family: var(--housing-mono); }
+.source-ledger-head { margin: 58px 0 20px; }
+.housing-source-list { border-top: 1px solid var(--housing-line); }
+.housing-source-list article { display: grid; grid-template-columns: 54px 1fr; gap: 14px; padding: 22px 0; border-bottom: 1px solid var(--housing-line); }
+.source-number { color: var(--housing-faint); font: 500 9px/1.5 var(--housing-mono); }
+.housing-source-list a,
+.housing-source-list article div > span:first-child { color: var(--housing-paper); font-size: 14px; font-weight: 600; text-decoration: none; }
+.housing-source-list a:hover { color: var(--housing-gold); }
+.housing-source-list p { margin: 5px 0 0; color: var(--housing-faint); font: 400 9px/1.55 var(--housing-mono); }
+.source-kind { display: inline-block; margin-top: 9px; padding: 5px 7px; border: 1px solid var(--housing-line); color: var(--housing-muted) !important; font: 500 8px/1 var(--housing-mono) !important; text-transform: uppercase; }
+
+.roadmap-cta { display: flex; align-items: center; justify-content: space-between; gap: 40px; margin: 34px 0 110px; padding: 30px; border: 1px solid rgba(255,177,92,.25); background: rgba(255,177,92,.04); text-decoration: none; }
+.roadmap-cta span:first-child { display: grid; gap: 8px; }
+.roadmap-cta small { color: var(--housing-gold); font: 500 9px/1 var(--housing-mono); text-transform: uppercase; }
+.roadmap-cta strong { font-size: 21px; }
+.roadmap-cta > span:last-child { max-width: 420px; color: var(--housing-faint); font: 400 10px/1.7 var(--housing-mono); text-align: right; }
+.roadmap-cta:hover { border-color: var(--housing-gold); }
+
+.housing-page .ctw-feedback-button { transform: scale(.82) !important; transform-origin: right bottom !important; }
+.housing-footer { border-top-color: var(--housing-line); background: #050605; }
+.housing-footer .signal-shell { display: flex; justify-content: space-between; gap: 20px; padding-block: 28px; color: var(--housing-faint); font: 400 9px/1 var(--housing-mono); text-transform: uppercase; }
+.housing-footer a { color: var(--housing-muted); text-decoration: none; }
+.housing-footer a:hover { color: var(--housing-gold); }
+
+.has-reveal .reveal { opacity: 0; transform: translateY(18px); transition: opacity .65s ease, transform .65s ease; }
+.has-reveal .reveal.is-visible { opacity: 1; transform: none; }
+
+@media (max-width: 1180px) {
+  .housing-layout { grid-template-columns: minmax(24px, 1fr) minmax(0, 880px) minmax(24px, 1fr); }
+  .housing-index { display: none; }
+  .housing-story { grid-column: 2; }
+}
+
+@media (max-width: 900px) {
+  .housing-hero-grid { grid-template-columns: 1fr; align-items: start; gap: 45px; }
+  .housing-verdict { max-width: 570px; }
+  .question-rail { grid-template-columns: repeat(5, minmax(120px, 1fr)); overflow-x: auto; }
+  .housing-layout { grid-template-columns: 24px minmax(0, 1fr) 24px; }
+  .housing-story { grid-column: 2; }
+  .distribution-grid,
+  .rate-and-price-grid { grid-template-columns: 1fr; }
+  .method-grid { grid-template-columns: repeat(2, 1fr); }
+  .roadmap-cta { align-items: flex-start; flex-direction: column; }
+  .roadmap-cta > span:last-child { text-align: left; }
+}
+
+@media (max-width: 640px) {
+  .housing-page .ctw-feedback-button { transform: scale(.68) !important; right: 10px !important; bottom: 10px !important; }
+  .housing-page .signal-shell { width: min(100% - 30px, 1180px); }
+  .housing-hero { padding-top: 104px; }
+  .housing-topics { padding-bottom: 39px; }
+  .housing-hero-grid { padding-bottom: 55px; }
+  .housing-hero-copy h1 { font-size: clamp(45px, 15vw, 68px); }
+  .housing-deck { margin-top: 25px; font-size: 16px; }
+  .housing-meta { display: grid; }
+  .housing-verdict { padding: 22px; }
+  .housing-layout { grid-template-columns: 15px minmax(0, 1fr) 15px; }
+  .housing-chapter { padding: 78px 0; }
+  .chapter-head { margin-bottom: 35px; }
+  .chapter-head h2 { font-size: 36px; }
+  .chapter-head > p:last-child { font-size: 15px; }
+  .lens-tabs { overflow-x: auto; scrollbar-width: none; }
+  .lens-tabs button { flex: 0 0 auto; }
+  .lens-panel { min-height: 0; padding: 22px; }
+  #lens-world { grid-template-columns: 1fr; }
+  .boundary-note { grid-column: 1; }
+  .world-number strong,
+  .world-derived strong { font-size: 54px; }
+  .nl-now-grid { grid-template-columns: 1fr; }
+  .comparison-header,
+  .chart-card-head,
+  .source-ledger-head { align-items: flex-start; flex-direction: column; }
+  .housing-legend { justify-content: flex-start; max-width: none; }
+  .housing-chart-card,
+  .overburden-card,
+  .tenure-card { padding: 21px; }
+  .housing-line-chart { min-width: 650px; }
+  .housing-chart-card { overflow-x: auto; }
+  .housing-chart-card figcaption,
+  .housing-chart-card details { min-width: 0; }
+  .supply-chart { min-width: 480px; }
+  .overburden-chart > div { grid-template-columns: 108px 1fr 43px; gap: 8px; }
+  .overburden-chart span { font-size: 8px; }
+  .distribution-conclusion,
+  .explanation-warning { grid-template-columns: 1fr; gap: 15px; }
+  .explanation-grid,
+  .possibility-grid { grid-template-columns: 1fr; }
+  .explanation-grid article,
+  .possibility-grid article { min-height: 0; }
+  .method-grid { grid-template-columns: 1fr; }
+  .method-details div { columns: 1; }
+  .housing-source-list article { grid-template-columns: 34px 1fr; }
+  .housing-footer .signal-shell { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .housing-page *, .housing-page *::before, .housing-page *::after { scroll-behavior: auto !important; transition-duration: .01ms !important; animation-duration: .01ms !important; }
+  .has-reveal .reveal { opacity: 1; transform: none; }
+}

--- a/ctw.studio/signals/housing/housing.js
+++ b/ctw.studio/signals/housing/housing.js
@@ -1,0 +1,455 @@
+(() => {
+  'use strict';
+
+  const DATA_URL = '../data/housing.json';
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const COLORS = {
+    housePrice: '#ffb15c',
+    rentPrice: '#79c7ff',
+    priceToIncome: '#f16f82',
+    priceToRent: '#b9a0ff',
+    grid: 'rgba(255,255,255,.12)',
+    muted: '#8f938c',
+    paper: '#f2f0e8'
+  };
+
+  const integer = new Intl.NumberFormat('en');
+  const compact = new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 1 });
+  const currency = new Intl.NumberFormat('en-NL', { style: 'currency', currency: 'EUR', maximumFractionDigits: 0 });
+  const dateFormat = new Intl.DateTimeFormat('en', { day: 'numeric', month: 'short', year: 'numeric', timeZone: 'UTC' });
+
+  const byId = (id) => document.getElementById(id);
+
+  function setText(id, value) {
+    const node = byId(id);
+    if (node) node.textContent = value;
+  }
+
+  function safeHttpsUrl(value) {
+    try {
+      const url = new URL(value);
+      return url.protocol === 'https:' ? url.href : null;
+    } catch {
+      return null;
+    }
+  }
+
+  function formatDate(value) {
+    const parsed = new Date(`${value}T00:00:00Z`);
+    return Number.isNaN(parsed.getTime()) ? value : dateFormat.format(parsed);
+  }
+
+  function periodNumber(value) {
+    if (value.includes('-Q')) {
+      const [year, quarter] = value.split('-Q').map(Number);
+      return year + (quarter - 1) / 4;
+    }
+    const [year, month = 1] = value.split('-').map(Number);
+    return year + (month - 1) / 12;
+  }
+
+  function svg(name, attributes = {}, text = '') {
+    const node = document.createElementNS(SVG_NS, name);
+    Object.entries(attributes).forEach(([key, value]) => node.setAttribute(key, String(value)));
+    if (text) node.textContent = text;
+    return node;
+  }
+
+  function createTable(captionText, headers, rows) {
+    const table = document.createElement('table');
+    const caption = document.createElement('caption');
+    caption.textContent = captionText;
+    const thead = document.createElement('thead');
+    const headRow = document.createElement('tr');
+    headers.forEach((header) => {
+      const th = document.createElement('th');
+      th.scope = 'col';
+      th.textContent = header;
+      headRow.append(th);
+    });
+    thead.append(headRow);
+    const tbody = document.createElement('tbody');
+    rows.forEach((row) => {
+      const tr = document.createElement('tr');
+      row.forEach((value, index) => {
+        const cell = document.createElement(index === 0 ? 'th' : 'td');
+        if (index === 0) cell.scope = 'row';
+        cell.textContent = value;
+        tr.append(cell);
+      });
+      tbody.append(tr);
+    });
+    table.append(caption, thead, tbody);
+    return table;
+  }
+
+  function hydrateHeadline(data) {
+    const priceIncome = data.netherlands.oecd.priceToIncome.latest;
+    const marketRenter = data.netherlands.overburden.byTenure.find((item) => item.code === 'RENT_MKT');
+    const mortgage = data.netherlands.ecbMortgage.latest;
+    const home = data.netherlands.cbs.existingHomes.latest;
+
+    setText('housing-data-date', formatDate(data.meta.dataUpdated));
+    setText('housing-verdict', data.meta.verdict);
+    setText('hero-price-income', `${priceIncome.value.toFixed(1)}`);
+    setText('hero-renter-burden', `${marketRenter.value.toFixed(1)}%`);
+    setText('hero-mortgage-rate', `${mortgage.value.toFixed(1)}%`);
+    setText('world-slum-share', `${data.world.slumShare.value.toFixed(1)}%`);
+    setText('world-derived-people', `≈${integer.format(data.world.estimatedPeople.valueMillions)}M`);
+    setText('nl-price-yoy', `${home.yearOnYearPct > 0 ? '+' : ''}${home.yearOnYearPct.toFixed(1)}%`);
+    setText('nl-price-period', `${home.period} · quality-adjusted index`);
+    setText('nl-average-price', currency.format(home.averagePurchasePriceEur));
+    setText('nl-price-income', priceIncome.value.toFixed(1));
+    setText('nl-overburden-total', `${data.netherlands.overburden.totalPct.toFixed(1)}%`);
+    setText('current-conclusion', data.interpretation.currentConclusion);
+  }
+
+  function setupLenses() {
+    const tabs = [...document.querySelectorAll('[role="tab"][data-lens]')];
+    const panels = [...document.querySelectorAll('[data-lens-panel]')];
+    if (!tabs.length || !panels.length) return;
+
+    function activate(id, focus = false) {
+      tabs.forEach((tab) => {
+        const selected = tab.dataset.lens === id;
+        tab.setAttribute('aria-selected', String(selected));
+        tab.tabIndex = selected ? 0 : -1;
+        if (selected && focus) tab.focus();
+      });
+      panels.forEach((panel) => {
+        panel.hidden = panel.dataset.lensPanel !== id;
+      });
+    }
+
+    tabs.forEach((tab, index) => {
+      tab.addEventListener('click', () => activate(tab.dataset.lens));
+      tab.addEventListener('keydown', (event) => {
+        if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return;
+        event.preventDefault();
+        let next = index;
+        if (event.key === 'ArrowLeft') next = (index - 1 + tabs.length) % tabs.length;
+        if (event.key === 'ArrowRight') next = (index + 1) % tabs.length;
+        if (event.key === 'Home') next = 0;
+        if (event.key === 'End') next = tabs.length - 1;
+        activate(tabs[next].dataset.lens, true);
+      });
+    });
+    activate('world');
+  }
+
+  function renderComparison(data) {
+    setText('comparison-period', data.comparisons.period);
+    const host = byId('country-comparison');
+    if (!host) return;
+    const countries = data.comparisons.countries;
+    const max = Math.max(...countries.map((item) => item.value), 150);
+    host.replaceChildren(...countries.map((item) => {
+      const row = document.createElement('div');
+      row.className = `country-row${item.code === 'NLD' ? ' country-row--primary' : ''}`;
+      row.title = item.whyIncluded;
+      const label = document.createElement('span');
+      label.textContent = item.name;
+      const track = document.createElement('div');
+      const baseline = document.createElement('i');
+      baseline.className = 'country-baseline';
+      baseline.style.left = `${(100 / max) * 100}%`;
+      const bar = document.createElement('b');
+      bar.style.width = `${(item.value / max) * 100}%`;
+      track.append(bar, baseline);
+      const value = document.createElement('strong');
+      value.textContent = item.value.toFixed(1);
+      row.append(label, track, value);
+      return row;
+    }));
+  }
+
+  function renderAffordabilityChart(data) {
+    const chart = byId('affordability-chart');
+    const legend = byId('affordability-legend');
+    const tableHost = byId('housing-price-table');
+    if (!chart || !legend || !tableHost) return;
+
+    const seriesKeys = ['housePrice', 'rentPrice', 'priceToIncome', 'priceToRent'];
+    const series = seriesKeys.map((key) => ({ key, ...data.netherlands.oecd[key] }));
+    const all = series.flatMap((item) => item.observations);
+    const xMin = Math.min(...all.map((item) => periodNumber(item.period)));
+    const xMax = Math.max(...all.map((item) => periodNumber(item.period)));
+    const yMin = 70;
+    const yMax = Math.ceil(Math.max(...all.map((item) => item.value)) / 20) * 20;
+    const width = 840;
+    const height = 410;
+    const margin = { top: 30, right: 30, bottom: 55, left: 58 };
+    const innerWidth = width - margin.left - margin.right;
+    const innerHeight = height - margin.top - margin.bottom;
+    const x = (period) => margin.left + ((periodNumber(period) - xMin) / (xMax - xMin)) * innerWidth;
+    const y = (value) => margin.top + ((yMax - value) / (yMax - yMin)) * innerHeight;
+
+    chart.replaceChildren(
+      svg('title', { id: 'affordability-title' }, 'Dutch housing indices since 2010'),
+      svg('desc', { id: 'affordability-desc' }, 'House prices, rents, price-to-income and price-to-rent indices, where 2015 equals 100.')
+    );
+
+    for (let value = 80; value <= yMax; value += 20) {
+      chart.append(
+        svg('line', { x1: margin.left, x2: width - margin.right, y1: y(value), y2: y(value), class: 'housing-grid-line' }),
+        svg('text', { x: margin.left - 10, y: y(value) + 4, 'text-anchor': 'end', class: 'housing-axis-label' }, String(value))
+      );
+    }
+    for (let year = Math.ceil(xMin); year <= Math.floor(xMax); year += 2) {
+      const px = margin.left + ((year - xMin) / (xMax - xMin)) * innerWidth;
+      chart.append(svg('text', { x: px, y: height - 20, 'text-anchor': 'middle', class: 'housing-axis-label' }, String(year)));
+    }
+    chart.append(svg('line', { x1: margin.left, x2: width - margin.right, y1: y(100), y2: y(100), class: 'housing-baseline-line' }));
+    chart.append(svg('text', { x: width - margin.right, y: y(100) - 7, 'text-anchor': 'end', class: 'housing-baseline-label' }, '2015 baseline'));
+
+    series.forEach((item) => {
+      const points = item.observations.map((observation) => `${x(observation.period)},${y(observation.value)}`).join(' L ');
+      chart.append(svg('path', { d: `M ${points}`, class: `housing-series housing-series--${item.key}` }));
+      const latest = item.latest;
+      chart.append(svg('circle', { cx: x(latest.period), cy: y(latest.value), r: 4, class: `housing-dot housing-dot--${item.key}` }));
+    });
+
+    legend.replaceChildren(...series.map((item) => {
+      const label = document.createElement('span');
+      const swatch = document.createElement('i');
+      swatch.style.background = COLORS[item.key];
+      label.append(swatch, item.label);
+      return label;
+    }));
+
+    const maps = Object.fromEntries(series.map((item) => [item.key, new Map(item.observations.map((row) => [row.period, row.value]))]));
+    const commonPeriods = series[0].observations.map((row) => row.period).filter((period) => series.every((item) => maps[item.key].has(period)));
+    const annualRows = commonPeriods
+      .filter((period) => period.endsWith('-Q4'))
+      .reverse()
+      .map((period) => [period, ...seriesKeys.map((key) => maps[key].get(period).toFixed(1))]);
+    tableHost.replaceChildren(createTable(
+      'Dutch housing indicators, fourth quarter values (2015=100)',
+      ['Period', 'House prices', 'Rents', 'Price / income', 'Price / rent'],
+      annualRows
+    ));
+  }
+
+  function renderMortgage(data) {
+    const rate = data.netherlands.ecbMortgage;
+    setText('mortgage-current', `${rate.latest.value.toFixed(1)}%`);
+    setText('mortgage-context', `The series low was ${rate.lowSince2015.value.toFixed(1)}% in ${rate.lowSince2015.period}; the latest observation is ${rate.latest.period}.`);
+    const marker = byId('mortgage-rate-marker');
+    if (marker) marker.style.left = `${Math.min(100, (rate.latest.value / 5) * 100)}%`;
+  }
+
+  function renderSupplyChart(data) {
+    const host = byId('supply-chart');
+    const tableHost = byId('supply-table');
+    if (!host || !tableHost) return;
+    const rows = data.netherlands.supplyVsHouseholds;
+    const max = Math.max(...rows.flatMap((row) => [row.netHousingAddition, row.householdGrowth]));
+    host.replaceChildren(...rows.map((item) => {
+      const group = document.createElement('div');
+      group.className = 'supply-year';
+      const bars = document.createElement('div');
+      bars.className = 'supply-bars';
+      const stock = document.createElement('i');
+      stock.className = 'supply-bar supply-bar--stock';
+      stock.style.height = `${(item.netHousingAddition / max) * 100}%`;
+      stock.title = `Net housing addition: ${integer.format(item.netHousingAddition)}`;
+      const households = document.createElement('i');
+      households.className = 'supply-bar supply-bar--households';
+      households.style.height = `${(item.householdGrowth / max) * 100}%`;
+      households.title = `Household growth: ${integer.format(item.householdGrowth)}`;
+      bars.append(stock, households);
+      const year = document.createElement('span');
+      year.textContent = item.year;
+      group.append(bars, year);
+      return group;
+    }));
+    tableHost.replaceChildren(createTable(
+      'Dutch dwelling-stock additions and private-household growth',
+      ['Year', 'New construction', 'Net stock addition', 'Household growth'],
+      [...rows].reverse().map((row) => [
+        String(row.year),
+        integer.format(row.newConstruction),
+        integer.format(row.netHousingAddition),
+        integer.format(row.householdGrowth)
+      ])
+    ));
+  }
+
+  function renderDistribution(data) {
+    const burden = data.netherlands.overburden;
+    setText('burden-period', burden.period);
+    const host = byId('overburden-chart');
+    if (host) {
+      const max = 45;
+      host.replaceChildren(...burden.byTenure.map((item) => {
+        const row = document.createElement('div');
+        const label = document.createElement('span');
+        label.textContent = item.tenure;
+        const track = document.createElement('div');
+        const bar = document.createElement('i');
+        bar.style.width = `${(item.value / max) * 100}%`;
+        track.append(bar);
+        const value = document.createElement('strong');
+        value.textContent = `${item.value.toFixed(1)}%`;
+        row.append(label, track, value);
+        return row;
+      }));
+    }
+
+    const shares = data.netherlands.tenure.shares.NL;
+    setText('tenure-own', `${shares.OWN.toFixed(1)}%`);
+    setText('tenure-market', `${shares.RENT_MKT.toFixed(1)}%`);
+    setText('tenure-reduced', `${shares.RENT_FR.toFixed(1)}%`);
+    const stack = byId('tenure-stack');
+    if (stack) {
+      const labels = [
+        ['OWN', 'Owner'],
+        ['RENT_MKT', 'Market rent'],
+        ['RENT_FR', 'Reduced rent']
+      ];
+      stack.replaceChildren(...labels.map(([key, label]) => {
+        const segment = document.createElement('i');
+        segment.className = `tenure-segment tenure-segment--${key.toLowerCase()}`;
+        segment.style.width = `${shares[key]}%`;
+        segment.title = `${label}: ${shares[key].toFixed(1)}%`;
+        return segment;
+      }));
+    }
+  }
+
+  function renderInterpretation(data) {
+    const explanationHost = byId('explanation-grid');
+    if (explanationHost) {
+      explanationHost.replaceChildren(...data.interpretation.competingExplanations.map((item, index) => {
+        const card = document.createElement('article');
+        const number = document.createElement('span');
+        number.textContent = String(index + 1).padStart(2, '0');
+        const title = document.createElement('h3');
+        title.textContent = item.title;
+        const text = document.createElement('p');
+        text.textContent = item.text;
+        card.append(number, title, text);
+        return card;
+      }));
+    }
+
+    const changeHost = byId('change-list');
+    if (changeHost) {
+      changeHost.replaceChildren(...data.interpretation.changeEvidence.map((text, index) => {
+        const item = document.createElement('li');
+        const number = document.createElement('span');
+        number.textContent = String(index + 1).padStart(2, '0');
+        const body = document.createElement('p');
+        body.textContent = text;
+        item.append(number, body);
+        return item;
+      }));
+    }
+
+    const possibilityHost = byId('possibility-grid');
+    if (possibilityHost) {
+      possibilityHost.replaceChildren(...data.interpretation.possibilities.map((item) => {
+        const card = document.createElement('article');
+        const label = document.createElement('span');
+        label.textContent = item.label;
+        const title = document.createElement('h3');
+        title.textContent = item.title;
+        const text = document.createElement('p');
+        text.textContent = item.text;
+        card.append(label, title, text);
+        return card;
+      }));
+    }
+  }
+
+  function renderSources(data) {
+    setText('housing-source-count', `${data.sources.length} sources`);
+    const host = byId('housing-source-list');
+    if (!host) return;
+    host.replaceChildren(...data.sources.map((source, index) => {
+      const item = document.createElement('article');
+      const number = document.createElement('span');
+      number.className = 'source-number';
+      number.textContent = String(index + 1).padStart(2, '0');
+      const body = document.createElement('div');
+      const sourceUrl = safeHttpsUrl(source.url);
+      const title = document.createElement(sourceUrl ? 'a' : 'span');
+      if (sourceUrl) {
+        title.href = sourceUrl;
+        title.target = '_blank';
+        title.rel = 'noreferrer';
+      }
+      title.textContent = sourceUrl ? `${source.title} ↗` : `${source.title} — URL unavailable`;
+      const meta = document.createElement('p');
+      meta.textContent = `${source.publisher} · accessed ${source.accessed}`;
+      const role = document.createElement('p');
+      role.textContent = source.role;
+      const kind = document.createElement('span');
+      kind.className = 'source-kind';
+      kind.textContent = source.kind;
+      body.append(title, meta, role, kind);
+      item.append(number, body);
+      return item;
+    }));
+  }
+
+  function setupReveal() {
+    const items = document.querySelectorAll('.reveal');
+    if (!('IntersectionObserver' in window) || window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      items.forEach((item) => item.classList.add('is-visible'));
+      return;
+    }
+    document.documentElement.classList.add('has-reveal');
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.06, rootMargin: '0px 0px -8% 0px' });
+    items.forEach((item) => observer.observe(item));
+  }
+
+  function setupStoryIndex() {
+    const links = new Map([...document.querySelectorAll('.housing-index a')].map((link) => [link.hash.slice(1), link]));
+    const sections = document.querySelectorAll('[data-observe-chapter]');
+    if (!links.size || !sections.length || !('IntersectionObserver' in window)) return;
+    const observer = new IntersectionObserver((entries) => {
+      const visible = entries.filter((entry) => entry.isIntersecting).sort((a, b) => b.intersectionRatio - a.intersectionRatio)[0];
+      if (!visible) return;
+      links.forEach((link) => link.classList.remove('active'));
+      links.get(visible.target.id)?.classList.add('active');
+    }, { threshold: [0.01, 0.25], rootMargin: '-20% 0px -62% 0px' });
+    sections.forEach((section) => observer.observe(section));
+  }
+
+  function showError(error) {
+    console.error('Could not initialize Housing & affordability', error);
+    setText('housing-data-date', 'Data unavailable');
+    setText('housing-verdict', 'The baked data could not be loaded. The source ledger and method remain available below.');
+  }
+
+  async function init() {
+    setupLenses();
+    setupReveal();
+    setupStoryIndex();
+    try {
+      const response = await fetch(DATA_URL, { cache: 'no-store' });
+      if (!response.ok) throw new Error(`Housing data request failed with ${response.status}`);
+      const data = await response.json();
+      hydrateHeadline(data);
+      renderComparison(data);
+      renderAffordabilityChart(data);
+      renderMortgage(data);
+      renderSupplyChart(data);
+      renderDistribution(data);
+      renderInterpretation(data);
+      renderSources(data);
+    } catch (error) {
+      showError(error);
+    }
+  }
+
+  init();
+})();

--- a/ctw.studio/signals/housing/index.html
+++ b/ctw.studio/signals/housing/index.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth housing-page" style="background:#070807">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Is an ordinary life becoming less attainable? — CTW Signals</title>
+  <meta name="description" content="A fact-first housing affordability briefing across the world, Europe, the Netherlands and selected country comparisons.">
+  <meta name="theme-color" content="#070807">
+  <link rel="icon" href="../../favicon.png">
+  <link rel="stylesheet" href="../../tailwind.css">
+  <link rel="stylesheet" href="../signals.css">
+  <link rel="stylesheet" href="housing.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
+  <script defer src="housing.js"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to the evidence</a>
+
+  <main id="main-content">
+    <header class="housing-hero" aria-labelledby="page-title">
+      <div class="signal-shell">
+        <nav class="topic-switcher housing-topics" aria-label="Signal topics">
+          <span class="topic-label">Signals /</span>
+          <a class="topic-pill" href="../">AI &amp; work</a>
+          <a class="topic-pill" href="../food/">Food &amp; planet</a>
+          <a class="topic-pill housing-active" href="./" aria-current="page">Housing</a>
+          <a class="topic-pill" href="../roadmap/">Roadmap</a>
+        </nav>
+
+        <div class="housing-hero-grid">
+          <div class="housing-hero-copy reveal">
+            <p class="brief-id"><span>Brief 003</span><span class="brief-line"></span><span>Housing &amp; affordability</span></p>
+            <h1 id="page-title">Is an ordinary life becoming <em>less attainable?</em></h1>
+            <p class="housing-deck">Prices are visible. Attainability is a system: income, rent, financing, supply, tenure, place and time. This briefing keeps them separate long enough to see who the market is working for.</p>
+            <div class="housing-meta">
+              <span>Data refreshed <strong id="housing-data-date">—</strong></span>
+              <span>World → Netherlands → comparisons</span>
+              <a href="#method">Read the method</a>
+            </div>
+          </div>
+
+          <aside class="housing-verdict reveal" aria-label="Current evidence conclusion">
+            <p class="verdict-label">Current read</p>
+            <p id="housing-verdict">Loading the evidence…</p>
+            <div class="verdict-scale" aria-label="Attainability assessment: severe pressure, unequal burden, incomplete relief">
+              <span class="active"></span><span class="active"></span><span></span>
+            </div>
+            <dl>
+              <div><dt>NL price / income</dt><dd id="hero-price-income">—</dd></div>
+              <div><dt>Market renters overburdened</dt><dd id="hero-renter-burden">—</dd></div>
+              <div><dt>New mortgage rate</dt><dd id="hero-mortgage-rate">—</dd></div>
+            </dl>
+          </aside>
+        </div>
+
+        <ol class="question-rail" aria-label="The five questions every Signals brief answers">
+          <li><span>01</span> Where now?</li>
+          <li><span>02</span> Which direction?</li>
+          <li><span>03</span> Who carries it?</li>
+          <li><span>04</span> Why?</li>
+          <li><span>05</span> What changes our mind?</li>
+        </ol>
+      </div>
+    </header>
+
+    <div class="housing-layout">
+      <aside class="housing-index" aria-label="Briefing chapters">
+        <p>The questions</p>
+        <nav>
+          <a href="#where-now"><span>01</span> Where now?</a>
+          <a href="#direction"><span>02</span> Direction</a>
+          <a href="#distribution"><span>03</span> Distribution</a>
+          <a href="#explanations"><span>04</span> Explanations</a>
+          <a href="#change-evidence"><span>05</span> Change evidence</a>
+          <a href="#possibilities"><span>→</span> Possibilities</a>
+        </nav>
+        <div class="index-legend">
+          <span><i class="dot world-dot"></i> World</span>
+          <span><i class="dot nl-dot"></i> NL / Europe</span>
+          <span><i class="dot compare-dot"></i> Comparisons</span>
+        </div>
+      </aside>
+
+      <article class="housing-story">
+        <section id="where-now" class="housing-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>01</span> Where are we now?</p>
+            <h2>There is no single housing market—and no single affordability number.</h2>
+            <p>Start at three scales. The world lens measures adequate shelter. The Dutch lens can ask about prices, incomes and tenure. Country comparisons show mechanisms, not winners.</p>
+          </header>
+
+          <noscript>
+            <style>.lens-tabs { display: none !important; }</style>
+            <p class="boundary-note">JavaScript is unavailable, so all geographic lenses are expanded below.</p>
+          </noscript>
+          <div class="lens-tabs" role="tablist" aria-label="Choose a geographic lens">
+            <button id="lens-tab-world" type="button" role="tab" aria-selected="true" aria-controls="lens-world" data-lens="world">World</button>
+            <button id="lens-tab-netherlands" type="button" role="tab" aria-selected="false" aria-controls="lens-netherlands" data-lens="netherlands-europe">Europe / Netherlands</button>
+            <button id="lens-tab-comparisons" type="button" role="tab" aria-selected="false" aria-controls="lens-comparisons" data-lens="comparisons">Selected countries</button>
+          </div>
+
+          <div class="lens-panels">
+            <section id="lens-world" class="lens-panel" role="tabpanel" aria-labelledby="lens-tab-world" data-lens-panel="world">
+              <div class="world-number">
+                <span>World · housing adequacy</span>
+                <strong id="world-slum-share">—</strong>
+                <p>of the urban population lived in slums in the latest global observation.</p>
+              </div>
+              <div class="world-derived">
+                <span>Derived scale</span>
+                <strong id="world-derived-people">—</strong>
+                <p>people, approximately—not a direct census. The calculation applies the slum share to world urban population in the same year.</p>
+              </div>
+              <p class="boundary-note"><strong>Boundary:</strong> this tells us about housing adequacy, not whether formal homes are affordable. No timely global series joins price, rent, income, financing and informal housing.</p>
+            </section>
+
+            <section id="lens-netherlands" class="lens-panel" role="tabpanel" aria-labelledby="lens-tab-netherlands" data-lens-panel="netherlands-europe">
+              <div class="nl-now-grid">
+                <article><span>Existing homes · latest y/y</span><strong id="nl-price-yoy">—</strong><small id="nl-price-period">—</small></article>
+                <article><span>Average transaction</span><strong id="nl-average-price">—</strong><small>Mix-sensitive; not the quality-adjusted index</small></article>
+                <article><span>Price-to-income</span><strong id="nl-price-income">—</strong><small>2015=100 · OECD</small></article>
+                <article><span>Housing-cost overburden</span><strong id="nl-overburden-total">—</strong><small>Total population · Eurostat</small></article>
+              </div>
+              <p class="lens-read"><strong>Read:</strong> price growth has resumed, and the income-adjusted index remains far above 2015. The national overburden average hides an extreme tenure split.</p>
+            </section>
+
+            <section id="lens-comparisons" class="lens-panel" role="tabpanel" aria-labelledby="lens-tab-comparisons" data-lens-panel="comparisons">
+              <div class="comparison-header">
+                <div><span>Harmonized comparison</span><h3>Price-to-income change since 2015</h3></div>
+                <span id="comparison-period" class="period-chip">—</span>
+              </div>
+              <div id="country-comparison" class="country-comparison" role="img" aria-label="Selected-country price-to-income index comparison"></div>
+              <p class="boundary-note"><strong>Not an absolute affordability ranking.</strong> Each country equals 100 in 2015. The bars show how its own price-to-income relationship changed—not how many years of income a home costs.</p>
+            </section>
+          </div>
+        </section>
+
+        <section id="direction" class="housing-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>02</span> What direction are we moving?</p>
+            <h2>Homes outran both incomes and rents. Cheaper money amplified the climb.</h2>
+            <p>Four OECD indices share the same 2015 base. They reveal why a price dip can coexist with poor affordability—and why nominal price headlines are not enough.</p>
+          </header>
+
+          <figure class="housing-chart-card">
+            <div class="chart-card-head">
+              <div><span>Netherlands · OECD · quarterly</span><h3>Prices, rents and affordability</h3></div>
+              <div id="affordability-legend" class="housing-legend" aria-label="Chart legend"></div>
+            </div>
+            <svg id="affordability-chart" class="housing-line-chart" viewBox="0 0 840 410" role="img" aria-labelledby="affordability-title affordability-desc">
+              <title id="affordability-title">Dutch housing indices since 2010</title>
+              <desc id="affordability-desc">House prices, rents, price-to-income and price-to-rent indices, where 2015 equals 100.</desc>
+            </svg>
+            <figcaption>All lines are indices, not euro prices. A value of 135 means 35% above that series’ 2015 relationship.</figcaption>
+            <details class="data-table-wrap">
+              <summary>View the chart as data</summary>
+              <div id="housing-price-table" class="data-table-scroll"></div>
+            </details>
+          </figure>
+
+          <div class="rate-and-price-grid">
+            <article class="mortgage-card">
+              <p>Financing condition</p>
+              <strong id="mortgage-current">—</strong>
+              <span>new Dutch mortgage rate</span>
+              <div class="rate-track" aria-hidden="true"><i id="mortgage-rate-marker"></i></div>
+              <p id="mortgage-context">Loading rate history…</p>
+            </article>
+            <article class="interpret-card">
+              <p>The common mistake</p>
+              <h3>“Prices fell, so homes became affordable.”</h3>
+              <p>A buyer experiences the monthly payment, required equity, taxes and competing household costs. If mortgage rates rise faster than prices fall, purchasing power can worsen.</p>
+            </article>
+          </div>
+
+          <figure class="housing-chart-card supply-card">
+            <div class="chart-card-head">
+              <div><span>Netherlands · CBS · annual alignment</span><h3>Did dwelling supply outpace household formation?</h3></div>
+              <span class="period-chip">2018–2024</span>
+            </div>
+            <div id="supply-chart" class="supply-chart" role="img" aria-label="Net additions to the Dutch housing stock compared with private household growth"></div>
+            <figcaption>Household growth compares 1 January with the following 1 January. National totals do not reveal location, price, suitability, vacancy or accumulated backlog.</figcaption>
+            <details class="data-table-wrap">
+              <summary>View the chart as data</summary>
+              <div id="supply-table" class="data-table-scroll"></div>
+            </details>
+          </figure>
+        </section>
+
+        <section id="distribution" class="housing-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>03</span> Who is benefiting—or carrying the cost?</p>
+            <h2>The average hides the housing divide.</h2>
+            <p>Eurostat’s housing-cost overburden threshold is the same across tenure groups: more than 40% of disposable household income. The outcomes are not remotely the same.</p>
+          </header>
+
+          <div class="distribution-grid">
+            <figure class="overburden-card">
+              <div class="chart-card-head"><div><span>Netherlands · Eurostat</span><h3>Overburden by tenure</h3></div><span id="burden-period" class="period-chip">—</span></div>
+              <div id="overburden-chart" class="overburden-chart" role="img" aria-label="Housing cost overburden rate by tenure"></div>
+              <figcaption>Housing allowances are reflected in disposable income and housing costs under EU-SILC conventions.</figcaption>
+            </figure>
+
+            <article class="tenure-card">
+              <p>Population by tenure</p>
+              <h3>A protected rental sector does not eliminate a market-renter crisis.</h3>
+              <div id="tenure-stack" class="tenure-stack" role="img" aria-label="Dutch population shares by housing tenure"></div>
+              <dl>
+                <div><dt>Owners</dt><dd id="tenure-own">—</dd></div>
+                <div><dt>Market rent</dt><dd id="tenure-market">—</dd></div>
+                <div><dt>Reduced / free rent</dt><dd id="tenure-reduced">—</dd></div>
+              </dl>
+              <p class="micro-note">These are population shares, not shares of the dwelling stock. “Reduced rent” includes social, subsidised and other below-market arrangements.</p>
+            </article>
+          </div>
+
+          <blockquote class="distribution-conclusion">
+            <span>What the distribution says</span>
+            <p>The primary split is not simply young versus old or rich versus poor. It is also between people whose housing cost is partly fixed or asset-backed and people repriced by a scarce market.</p>
+          </blockquote>
+        </section>
+
+        <section id="explanations" class="housing-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>04</span> What are the competing explanations?</p>
+            <h2>“Build more” is directionally useful—and analytically incomplete.</h2>
+            <p>Supply matters. So do credit, household formation, location, tenure, tax, regulation and the inherited stock. The evidence is strongest when explanations compete rather than take turns as slogans.</p>
+          </header>
+          <div id="explanation-grid" class="explanation-grid"></div>
+          <aside class="explanation-warning">
+            <strong>Do not read correlation as allocation.</strong>
+            <p>A national increase in stock can occur while lower-income renters, first-time buyers or a specific city experience worsening access. The missing join is often who received which home, where, and at what total monthly burden.</p>
+          </aside>
+        </section>
+
+        <section id="change-evidence" class="housing-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>05</span> What evidence would change our conclusion?</p>
+            <h2>A useful dashboard must make itself falsifiable.</h2>
+            <p>Our current conclusion is not “housing only gets worse.” These are the observations that would justify a more optimistic reading.</p>
+          </header>
+          <ol id="change-list" class="change-list"></ol>
+          <div class="current-answer">
+            <span>Current conclusion · July 2026</span>
+            <p id="current-conclusion">Loading…</p>
+          </div>
+        </section>
+
+        <section id="possibilities" class="housing-chapter possibility-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>→</span> What might this make possible?</p>
+            <h2>Pressure reveals capabilities society is missing.</h2>
+            <p>Explicitly labelled hypotheses—not investment advice, forecasts or optimism pasted over bad news.</p>
+          </header>
+          <div id="possibility-grid" class="possibility-grid"></div>
+        </section>
+
+        <section id="sources" class="housing-chapter source-chapter reveal" data-observe-chapter>
+          <header class="chapter-head">
+            <p class="chapter-kicker"><span>Method</span> Sources &amp; boundaries</p>
+            <h2>Every number keeps its denominator.</h2>
+          </header>
+          <div id="method" class="method-grid">
+            <article><span>01</span><h3>Three lenses</h3><p>World housing adequacy, Dutch and European affordability, then selected countries chosen for mechanisms rather than rank.</p></article>
+            <article><span>02</span><h3>Same-base comparisons</h3><p>OECD index values show change from 2015. They do not show absolute price levels or years of income needed.</p></article>
+            <article><span>03</span><h3>Aligned supply</h3><p>Annual dwelling-stock change is compared with private-household growth over the matching January-to-January interval.</p></article>
+            <article><span>04</span><h3>Baked, reviewable data</h3><p>Official observations are refreshed by script, inspected and committed. Visitors do not call upstream APIs.</p></article>
+          </div>
+          <details class="method-details">
+            <summary>Read the refresh and derivation notes</summary>
+            <div>
+              <p><strong>World estimate.</strong> The affected-population figure is derived from two World Bank series for the same year. It is approximate and is not a direct census.</p>
+              <p><strong>Purchase price.</strong> CBS’s average transaction price changes with the mix of homes sold. The quality-adjusted index is the correct trend measure.</p>
+              <p><strong>Overburden.</strong> EU-SILC is survey-based. Tenure groups can differ in income, age, geography and dwelling quality; the chart describes the distribution but does not identify one causal mechanism.</p>
+              <p><strong>Refresh.</strong> Run <code>python3 signals/scripts/update_housing_data.py</code> from <code>ctw.studio</code>, then inspect periods, revisions, definitions and this narrative before publishing.</p>
+            </div>
+          </details>
+          <div class="source-ledger-head"><div><span>Evidence ledger</span><h3>Official and institution-grade sources</h3></div><span id="housing-source-count">—</span></div>
+          <div id="housing-source-list" class="housing-source-list"></div>
+        </section>
+
+        <a class="roadmap-cta reveal" href="../roadmap/">
+          <span><small>Signals atlas</small><strong>See the next ten briefings →</strong></span>
+          <span>Housing → Prosperity → Energy &amp; Compute → Healthspan → Demography → Science</span>
+        </a>
+      </article>
+    </div>
+  </main>
+
+  <footer class="signal-footer housing-footer">
+    <div class="signal-shell">
+      <a href="../../">CTW Studio</a>
+      <span>Brief 003 · Housing &amp; affordability</span>
+      <a href="#main-content">Back to top ↑</a>
+    </div>
+  </footer>
+  <script src="../../feedback.js"></script>
+</body>
+</html>

--- a/ctw.studio/signals/index.html
+++ b/ctw.studio/signals/index.html
@@ -1,0 +1,442 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth" style="background: #050505">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Is AI transforming the job market? — CTW Signals</title>
+  <meta name="description" content="A fact-first visual briefing on AI, jobs, exposure, productivity and what the labour-market numbers actually show.">
+  <link rel="canonical" href="https://ctw.studio/signals/">
+
+  <meta property="og:title" content="Is AI transforming the job market? — CTW Signals">
+  <meta property="og:description" content="Observed data, forecasts and experiments—kept separate. A visual evidence briefing from CTW Studio.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://ctw.studio/signals/">
+  <meta property="og:image" content="https://ctw.studio/og-image.png">
+  <meta name="twitter:card" content="summary_large_image">
+
+  <link rel="icon" type="image/png" href="../favicon.png">
+  <link rel="apple-touch-icon" href="../favicon.png">
+  <link rel="stylesheet" href="../tailwind.css">
+  <link rel="stylesheet" href="signals.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" media="print" onload="this.media='all'">
+  <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap"></noscript>
+  <script src="dashboard.js" defer></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to the evidence</a>
+  <script src="../nav.js" data-base="../" data-active="signals"></script>
+
+  <main id="main-content">
+    <header class="signal-hero">
+      <div class="signal-shell">
+        <div class="topic-switcher" aria-label="CTW Signals topics">
+          <span class="topic-switcher__label">CTW Signals</span>
+          <a class="topic-pill topic-pill--active" href="./" aria-current="page">AI &amp; work</a>
+          <a class="topic-pill" href="food/">Food, animals &amp; planet</a>
+          <span class="topic-pill topic-pill--future">Housing &amp; affordability <span>queued</span></span>
+        </div>
+
+        <div class="hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Brief 001 · Evidence over headlines</p>
+            <h1>Is AI taking jobs—or <em>changing</em> them?</h1>
+            <p class="hero-deck">
+              A fact-first storyboard about a fast-moving technology and a slow-moving labour market.
+              We compare what is <strong>observed</strong>, what is merely <strong>exposed</strong>, what happened in
+              <strong>experiments</strong>, and what remains a <strong>forecast</strong>.
+            </p>
+            <div class="hero-meta">
+              <span class="live-dot" aria-hidden="true"></span>
+              <span id="data-as-of">Loading the latest official series…</span>
+              <a href="#method">How to read this</a>
+            </div>
+          </div>
+
+          <aside class="verdict-card" aria-label="Current evidence verdict">
+            <div class="verdict-card__topline">
+              <span>Current read</span>
+              <span class="verdict-status"><i aria-hidden="true"></i> Mixed signal</span>
+            </div>
+            <p class="verdict-card__statement">Transformation is visible.<br>Mass displacement is <span>not established.</span></p>
+            <div class="verdict-scale" aria-label="Evidence scale: early signal, concentrated effects, broad disruption">
+              <span class="verdict-scale__active">Early signal</span>
+              <span class="verdict-scale__active">Concentrated effects</span>
+              <span>Broad disruption</span>
+            </div>
+            <p class="verdict-card__note">The strongest observed warning is among young workers in highly exposed occupations—not across the whole economy.</p>
+          </aside>
+        </div>
+
+        <div class="hero-question-row" aria-label="Questions this briefing answers">
+          <span>01 Is the market breaking?</span>
+          <span>02 How many jobs are exposed?</span>
+          <span>03 Who feels it first?</span>
+          <span>04 What do forecasts really say?</span>
+        </div>
+      </div>
+    </header>
+
+    <div class="signal-shell story-layout">
+      <aside class="story-index" aria-label="Briefing chapters">
+        <p class="story-index__title">The storyboard</p>
+        <ol>
+          <li><a href="#big-picture"><span>01</span> The whole market</a></li>
+          <li><a href="#exposure"><span>02</span> Exposure ≠ loss</a></li>
+          <li><a href="#uneven"><span>03</span> Uneven effects</a></li>
+          <li><a href="#expectations"><span>04</span> Expectations</a></li>
+          <li><a href="#work-changes"><span>05</span> Work changes</a></li>
+          <li><a href="#answer"><span>06</span> The honest answer</a></li>
+        </ol>
+        <div class="legend-mini">
+          <p><i class="key key--observed"></i> Observed</p>
+          <p><i class="key key--exposure"></i> Exposure</p>
+          <p><i class="key key--experiment"></i> Experiment</p>
+          <p><i class="key key--forecast"></i> Forecast</p>
+        </div>
+      </aside>
+
+      <div class="story-content">
+        <section id="big-picture" class="story-section reveal">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow eyebrow--observed"><span>Observed</span> · U.S. monthly data</p>
+              <h2>The labour market is cooling.<br><em>That is not the same as an AI collapse.</em></h2>
+            </div>
+            <span class="chapter-number">01</span>
+          </div>
+          <p class="section-intro">
+            Job openings have fallen since ChatGPT arrived, while unemployment is modestly higher. But openings had already peaked in March 2022—eight months before ChatGPT. These lines describe the market; they do not assign a cause.
+          </p>
+
+          <div class="metric-strip">
+            <article>
+              <span class="metric-label">Latest openings</span>
+              <strong id="openings-latest">—</strong>
+              <small id="openings-latest-date">U.S. · loading</small>
+            </article>
+            <article>
+              <span class="metric-label">Since Nov. 2022</span>
+              <strong id="openings-change">—</strong>
+              <small>openings · not AI-attributed</small>
+            </article>
+            <article>
+              <span class="metric-label">Latest unemployment</span>
+              <strong id="unemployment-latest">—</strong>
+              <small id="unemployment-latest-date">U.S. · loading</small>
+            </article>
+          </div>
+
+          <article class="chart-card chart-card--wide">
+            <div class="chart-card__header">
+              <div>
+                <p class="chart-kicker">Live indicator</p>
+                <h3 id="market-chart-title">U.S. job openings</h3>
+              </div>
+              <div class="chart-switcher" role="group" aria-label="Choose labour-market indicator">
+                <button type="button" data-series="openings" aria-pressed="true">Openings</button>
+                <button type="button" data-series="hires" aria-pressed="false">Hires</button>
+                <button type="button" data-series="unemployment" aria-pressed="false">Unemployment</button>
+              </div>
+            </div>
+            <div class="line-chart-wrap">
+              <svg id="market-chart" class="line-chart" viewBox="0 0 780 360" role="img" tabindex="0" aria-labelledby="market-chart-title" aria-describedby="market-chart-desc market-chart-keyboard-help"></svg>
+              <div id="chart-tooltip" class="chart-tooltip" role="status" aria-live="polite" hidden></div>
+            </div>
+            <p id="market-chart-desc" class="chart-description">Loading official monthly observations…</p>
+            <p id="market-chart-keyboard-help" class="sr-only">Focus the chart and use the left and right arrow keys to inspect monthly observations. The complete values are also available in the data table below.</p>
+            <div class="chart-footer">
+              <span><i class="annotation-line" aria-hidden="true"></i> ChatGPT public launch · Nov. 2022</span>
+              <a id="market-source" href="https://fred.stlouisfed.org/series/JTSJOL" target="_blank" rel="noreferrer">BLS via FRED ↗</a>
+            </div>
+            <details class="data-table-wrap">
+              <summary>View the chart as data</summary>
+              <div id="market-data-table" class="data-table-scroll"></div>
+            </details>
+          </article>
+
+          <aside class="reading-note">
+            <span class="reading-note__mark">!</span>
+            <div>
+              <strong>What the line can tell us</strong>
+              <p>Whether hiring conditions are tightening or loosening.</p>
+            </div>
+            <div>
+              <strong>What it cannot tell us</strong>
+              <p>Whether AI, interest rates, post-pandemic normalization, or another force caused the movement.</p>
+            </div>
+          </aside>
+        </section>
+
+        <section id="exposure" class="story-section reveal">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow eyebrow--exposure"><span>Exposure estimate</span> · Global</p>
+              <h2>One in four workers is exposed.<br><em>Only a small share is highly exposed.</em></h2>
+            </div>
+            <span class="chapter-number">02</span>
+          </div>
+          <p class="section-intro">
+            The ILO asks whether generative AI can perform tasks inside an occupation. It does not count redundancies. That distinction changes the story.
+          </p>
+
+          <article class="exposure-card">
+            <div class="exposure-card__headline">
+              <div>
+                <span>Some GenAI exposure</span>
+                <strong>≈<b id="exposure-any">25</b>%</strong>
+              </div>
+              <div>
+                <span>Highest exposure category</span>
+                <strong><b id="exposure-high">3.3</b>%</strong>
+              </div>
+            </div>
+            <div id="exposure-chart" class="exposure-chart" role="img" aria-label="Of global employment, about 25 percent is in occupations with some generative AI exposure, including 3.3 percent in the highest exposure category."></div>
+            <div class="exposure-legend">
+              <span><i class="key key--high"></i> Highest exposure</span>
+              <span><i class="key key--exposure"></i> Other exposure</span>
+              <span><i class="key key--muted"></i> Lower / no measured exposure</span>
+            </div>
+          </article>
+
+          <div class="two-column-notes">
+            <article class="fact-card">
+              <span class="fact-card__index">A</span>
+              <p class="fact-card__label">The likely mechanism</p>
+              <h3>Tasks change before occupations disappear.</h3>
+              <p>Most occupations combine automatable tasks with judgement, physical work, relationships, accountability, or context that still needs people.</p>
+            </article>
+            <article class="fact-card">
+              <span class="fact-card__index">B</span>
+              <p class="fact-card__label">The uneven distribution</p>
+              <h3>Exposure is higher for women in the top category.</h3>
+              <div class="mini-comparison" aria-label="Highest exposure: women 4.7 percent, men 2.4 percent">
+                <div><span>Women</span><i style="--value: 4.7"></i><b>4.7%</b></div>
+                <div><span>Men</span><i style="--value: 2.4"></i><b>2.4%</b></div>
+              </div>
+              <p>The ILO links the gap to the concentration of women in clerical work, especially in high-income countries.</p>
+            </article>
+          </div>
+        </section>
+
+        <section id="uneven" class="story-section reveal">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow eyebrow--observed"><span>Observed association</span> · U.S.</p>
+              <h2>The first effects may appear<br><em>at the entry ramp, not the exit door.</em></h2>
+            </div>
+            <span class="chapter-number">03</span>
+          </div>
+          <p class="section-intro">
+            Two rigorous analyses can be true at the same time because they look through different lenses: one at a vulnerable subgroup, the other at the entire labour market.
+          </p>
+
+          <div class="contrast-grid">
+            <article class="contrast-card contrast-card--warning">
+              <div class="contrast-card__type">Concentrated signal</div>
+              <strong class="contrast-card__number">−<span id="early-career-decline">16</span>%</strong>
+              <h3>Relative employment decline for ages 22–25 in the most AI-exposed occupations.</h3>
+              <p>Stanford’s U.S. payroll-data working paper finds the decline after firm-level controls, while older workers in the same occupations and workers in less-exposed fields were steadier.</p>
+              <footer>
+                <span>Working paper · revised Nov. 2025</span>
+                <a href="#source-stanford-canaries">Scope &amp; source ↓</a>
+              </footer>
+            </article>
+
+            <article class="contrast-card contrast-card--calm">
+              <div class="contrast-card__type">Economy-wide counterpoint</div>
+              <div class="no-break-graphic" aria-hidden="true"><span></span><span></span><span></span><span></span><span></span></div>
+              <h3>No discernible broad disruption in the first 33 months after ChatGPT.</h3>
+              <p>Yale’s Budget Lab found exposure, automation, and augmentation measures were not related to employment or unemployment changes across the whole market.</p>
+              <footer>
+                <span>Economy-wide analysis · Oct. 2025</span>
+                <a href="#source-yale-budget-lab">Scope &amp; source ↓</a>
+              </footer>
+            </article>
+          </div>
+
+          <div class="interpretation-panel">
+            <p class="interpretation-panel__label">Interpretation</p>
+            <p><strong>There is a canary, but not yet a mine-wide alarm.</strong> Entry-level hiring can weaken before aggregate employment moves. It can also be affected by interest rates, post-pandemic tech corrections, education choices and remote-work shifts. Watch the subgroup; do not inflate it into an economy-wide count.</p>
+          </div>
+
+          <article class="watchlist-card">
+            <div>
+              <p class="chart-kicker">What would change our mind?</p>
+              <h3>Signals worth watching next</h3>
+            </div>
+            <ol>
+              <li><span>01</span><p><strong>Persistence</strong>Do early-career declines continue across revisions and datasets?</p></li>
+              <li><span>02</span><p><strong>Diffusion</strong>Do effects spread from highly exposed occupations to the wider labour market?</p></li>
+              <li><span>03</span><p><strong>Mechanism</strong>Do employer records tie fewer hires or separations explicitly to AI deployment?</p></li>
+              <li><span>04</span><p><strong>Compensation</strong>Do wages, hours and job quality move before headcount does?</p></li>
+            </ol>
+          </article>
+        </section>
+
+        <section id="expectations" class="story-section reveal">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow eyebrow--forecast"><span>Forecast</span> · Global to 2030</p>
+              <h2>The scary number is rarely<br><em>the whole number.</em></h2>
+            </div>
+            <span class="chapter-number">04</span>
+          </div>
+          <p class="section-intro">
+            The World Economic Forum’s headline is not “92 million jobs vanish.” Its employer-survey scenario pairs displacement with more creation—and covers every structural macrotrend, not AI alone.
+          </p>
+
+          <article class="chart-card forecast-card">
+            <div class="forecast-summary">
+              <div><span>Projected creation</span><strong>+170M</strong></div>
+              <div><span>Projected displacement</span><strong>−92M</strong></div>
+              <div class="forecast-summary__net"><span>Projected net</span><strong>+78M</strong></div>
+            </div>
+            <div id="forecast-chart" class="bar-chart" role="img" aria-label="World Economic Forum forecast for 2025 to 2030: 170 million jobs created, 92 million displaced, net gain 78 million."></div>
+            <p class="forecast-scope"><strong>Scope check:</strong> 1.2 billion formal jobs, 2025–2030, across technology, demographics, geoeconomic fragmentation, the green transition and other forces.</p>
+          </article>
+
+          <div class="forecast-caveat">
+            <span>22%</span>
+            <p><strong>Projected structural churn</strong>—jobs created plus jobs displaced as a share of the formal jobs studied. It describes movement, not inevitable unemployment.</p>
+          </div>
+        </section>
+
+        <section id="work-changes" class="story-section reveal">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow eyebrow--experiment"><span>Workplace experiment</span> · One company</p>
+              <h2>Before AI replaces work,<br><em>it can redistribute expertise.</em></h2>
+            </div>
+            <span class="chapter-number">05</span>
+          </div>
+          <p class="section-intro">
+            In a study of 5,179 customer-support agents, an AI assistant increased issues resolved per hour—especially for novice and lower-skilled workers. This is strong evidence about a task setting, not a universal employment forecast.
+          </p>
+
+          <div class="work-grid">
+            <article class="chart-card productivity-card">
+              <div class="chart-card__header">
+                <div>
+                  <p class="chart-kicker">Productivity gain</p>
+                  <h3>Issues resolved per hour</h3>
+                </div>
+                <span class="sample-badge">n = 5,179</span>
+              </div>
+              <div id="productivity-chart" class="productivity-chart" role="img" aria-label="Average productivity improved by 14 percent, and novice and lower-skilled worker productivity improved by 34 percent."></div>
+              <p class="chart-description">The largest gain accrued to workers with less experience. Experienced, highly skilled workers saw minimal impact.</p>
+            </article>
+
+            <article class="adoption-card">
+              <p class="chart-kicker">Adoption context · 2025</p>
+              <strong><span id="adoption-rate">88</span>%</strong>
+              <h3>of surveyed organizations reported using AI.</h3>
+              <div class="adoption-ring" aria-hidden="true"><span></span></div>
+              <p>Adoption is widespread; measured workforce effects are not. That gap is exactly why outcomes must be tracked separately from usage.</p>
+            </article>
+          </div>
+        </section>
+
+        <section id="answer" class="story-section answer-section reveal">
+          <div class="section-heading">
+            <div>
+              <p class="eyebrow">Current answer · July 2026</p>
+              <h2>So, is AI transforming<br><em>the job market?</em></h2>
+            </div>
+            <span class="chapter-number">06</span>
+          </div>
+
+          <div class="answer-card">
+            <p class="answer-card__lead">Yes—but transformation is not a synonym for net job loss.</p>
+            <div class="answer-grid">
+              <article>
+                <span class="answer-icon answer-icon--yes">✓</span>
+                <h3>What is established</h3>
+                <ul>
+                  <li>AI exposure reaches a meaningful share of occupations.</li>
+                  <li>AI can materially change productivity and task performance.</li>
+                  <li>Early-career workers in highly exposed U.S. occupations show a concerning employment signal.</li>
+                </ul>
+              </article>
+              <article>
+                <span class="answer-icon answer-icon--no">×</span>
+                <h3>What is not established</h3>
+                <ul>
+                  <li>That today’s broad market cooling was caused mainly by AI.</li>
+                  <li>That exposed jobs will disappear one-for-one.</li>
+                  <li>That economy-wide AI mass unemployment is already visible in the data.</li>
+                </ul>
+              </article>
+              <article>
+                <span class="answer-icon answer-icon--watch">→</span>
+                <h3>Our working prediction</h3>
+                <ul>
+                  <li>Near-term disruption will remain uneven and hiring-led.</li>
+                  <li>Junior pipelines and routine cognitive tasks deserve the closest watch.</li>
+                  <li>Job redesign, skill shifts and wage effects may arrive before aggregate headcount losses.</li>
+                </ul>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section id="method" class="story-section methodology-section reveal">
+          <div class="section-heading section-heading--compact">
+            <div>
+              <p class="eyebrow">Method &amp; sources</p>
+              <h2>How this briefing stays factual</h2>
+            </div>
+          </div>
+
+          <div class="method-grid">
+            <article><span>01</span><h3>Label the evidence</h3><p>Observed outcomes, exposure models, experiments and forecasts never share an unlabeled axis.</p></article>
+            <article><span>02</span><h3>Match the scope</h3><p>A subgroup result stays a subgroup result. A one-company experiment stays a one-company experiment.</p></article>
+            <article><span>03</span><h3>Separate timing from cause</h3><p>“After ChatGPT” is not automatically “because of ChatGPT.”</p></article>
+            <article><span>04</span><h3>Keep uncertainty visible</h3><p>Working papers, survey scenarios, revisions and source limitations travel with the number.</p></article>
+          </div>
+
+          <div class="source-ledger">
+            <div class="source-ledger__header">
+              <div>
+                <p class="chart-kicker">Evidence ledger</p>
+                <h3>Primary and institution-grade sources</h3>
+              </div>
+              <span id="source-count">8 sources</span>
+            </div>
+            <ol id="sources-list" class="sources-list" aria-live="polite">
+              <li>Loading source details…</li>
+            </ol>
+          </div>
+        </section>
+
+        <section class="future-section reveal" aria-labelledby="future-title">
+          <div>
+            <p class="eyebrow">Also in Signals · Brief 002</p>
+            <h2 id="future-title">What does eating animals cost—beyond the price tag?</h2>
+            <p>Count the lives, then trace the emissions, land, forests, water, oceans and health evidence—with fish uncertainty and system boundaries kept visible.</p>
+          </div>
+          <div class="future-metrics" aria-label="Food system dashboard measures">
+            <span>Animals killed</span>
+            <span>Climate footprint</span>
+            <span>Land &amp; forests</span>
+            <span>Health evidence</span>
+          </div>
+          <a class="future-badge" href="food/">Open Brief 002 →</a>
+        </section>
+      </div>
+    </div>
+  </main>
+
+  <footer class="signal-footer">
+    <div class="signal-shell signal-footer__inner">
+      <p><strong>CTW Signals</strong> turns consequential claims into inspectable evidence.</p>
+      <div><a href="../">CTW Studio</a><a href="../portfolio/">Work</a><a href="#main-content">Back to top ↑</a></div>
+    </div>
+  </footer>
+
+  <noscript>
+    <div class="noscript-note">The live charts require JavaScript. All interpretations and source links remain available above.</div>
+  </noscript>
+</body>
+</html>

--- a/ctw.studio/signals/index.html
+++ b/ctw.studio/signals/index.html
@@ -35,7 +35,8 @@
           <span class="topic-switcher__label">CTW Signals</span>
           <a class="topic-pill topic-pill--active" href="./" aria-current="page">AI &amp; work</a>
           <a class="topic-pill" href="food/">Food, animals &amp; planet</a>
-          <span class="topic-pill topic-pill--future">Housing &amp; affordability <span>queued</span></span>
+          <a class="topic-pill" href="housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="roadmap/">Roadmap</a>
         </div>
 
         <div class="hero-grid">

--- a/ctw.studio/signals/roadmap/index.html
+++ b/ctw.studio/signals/roadmap/index.html
@@ -1,0 +1,205 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth roadmap-page" style="background:#080907">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The Signals atlas — CTW Signals</title>
+  <meta name="description" content="The evidence standard, geographic lenses and publication roadmap for ten CTW Signals briefings.">
+  <meta name="theme-color" content="#080907">
+  <link rel="icon" href="../../favicon.png">
+  <link rel="stylesheet" href="../../tailwind.css">
+  <link rel="stylesheet" href="../signals.css">
+  <link rel="stylesheet" href="roadmap.css">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
+</head>
+<body>
+  <a class="skip-link" href="#main-content">Skip to the atlas</a>
+  <main id="main-content">
+    <header class="atlas-hero">
+      <div class="atlas-shell">
+        <nav class="atlas-topics" aria-label="Signal topics">
+          <span>Signals /</span>
+          <a href="../">AI &amp; work</a>
+          <a href="../food/">Food &amp; planet</a>
+          <a href="../housing/">Housing</a>
+          <a class="active" href="./" aria-current="page">Roadmap</a>
+        </nav>
+        <p class="atlas-kicker">The Signals atlas · Version 1</p>
+        <h1>Important questions,<br><em>held to one standard.</em></h1>
+        <p class="atlas-deck">Ten long-horizon briefings about whether life is becoming more capable, affordable, healthy, resilient and free—not a scoreboard of context-free metrics.</p>
+        <div class="atlas-status">
+          <span><strong>3</strong> briefings published</span>
+          <span><strong>1 of 10</strong> atlas briefs published</span>
+          <span><strong>9</strong> atlas briefs planned</span>
+        </div>
+      </div>
+    </header>
+
+    <section class="atlas-standard" aria-labelledby="standard-title">
+      <div class="atlas-shell atlas-two-column">
+        <div class="standard-copy">
+          <p class="section-label">The organizing idea</p>
+          <h2 id="standard-title">Every briefing answers the same five questions.</h2>
+          <p>The topic changes. The burden of proof does not. A Signals brief must show its current read, its direction, its distribution, its rival explanations and the conditions under which we would change our mind.</p>
+        </div>
+        <ol class="standard-questions">
+          <li><span>01</span><strong>Where are we now?</strong></li>
+          <li><span>02</span><strong>What direction are we moving?</strong></li>
+          <li><span>03</span><strong>Who is benefiting or carrying the cost?</strong></li>
+          <li><span>04</span><strong>What are the competing explanations?</strong></li>
+          <li><span>05</span><strong>What evidence would change our current conclusion?</strong></li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="atlas-lenses" aria-labelledby="lens-title">
+      <div class="atlas-shell">
+        <div class="section-head">
+          <p class="section-label">Geographic discipline</p>
+          <h2 id="lens-title">Three lenses. Three different jobs.</h2>
+        </div>
+        <div class="lens-grid">
+          <article><span>01 · World</span><h3>The structural picture</h3><p>Global scale, long-run direction and the constraints a national dashboard cannot see.</p></article>
+          <article><span>02 · Europe / Netherlands</span><h3>The lived context</h3><p>The institutions, political choices and economic conditions closest to everyday life.</p></article>
+          <article><span>03 · Selected countries</span><h3>Useful comparisons</h3><p>Cases selected to illuminate mechanisms—not arbitrary rankings or league tables.</p></article>
+        </div>
+      </div>
+    </section>
+
+    <section class="atlas-topics-section" aria-labelledby="topics-title">
+      <div class="atlas-shell">
+        <div class="section-head topics-head">
+          <div><p class="section-label">The ten-subject atlas</p><h2 id="topics-title">What Signals will track.</h2></div>
+          <p>Each card defines a standing evidence brief, not a one-off article. The indicators can evolve; the question remains inspectable.</p>
+        </div>
+
+        <ol class="atlas-grid">
+          <li class="atlas-card atlas-card--published" data-status="published">
+            <a href="../housing/">
+              <header><span>01</span><small>Published · Brief 003</small></header>
+              <h3>Housing &amp; affordability</h3>
+              <p>Track prices against incomes, rents, mortgage costs and total monthly burden; construction against household formation; social housing, waiting times, homelessness, vacancy and who gains from scarcity.</p>
+              <strong>Read the brief →</strong>
+            </a>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>02</span><small>Planned · Next</small></header>
+              <h3>Prosperity</h3>
+              <p>Track median disposable income, productivity, real wages, essential costs, wealth distribution, public services, time use and whether economic gains reach ordinary households.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>03</span><small>Planned</small></header>
+              <h3>Energy &amp; compute</h3>
+              <p>Track demand, prices, grid congestion, clean generation, firm capacity, storage, transmission, data centres, AI load, emissions and which constraints are physical rather than rhetorical.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>04</span><small>Planned</small></header>
+              <h3>Healthspan &amp; care</h3>
+              <p>Track healthy life years, preventable mortality, chronic and mental illness, access and waiting times, workforce capacity, antimicrobial resistance and whether longer lives are better lives.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>05</span><small>Planned</small></header>
+              <h3>Demography, migration &amp; aging</h3>
+              <p>Track fertility, age structure, migration, dependency, household formation, regional divergence, integration and what population change means for housing, care, work and public finance.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>06</span><small>Planned</small></header>
+              <h3>Democracy, trust &amp; information</h3>
+              <p>Track institutional trust, rule of law, corruption, turnout, polarization, press freedom, information concentration, online manipulation and how AI-mediated discovery changes public knowledge.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>07</span><small>Planned · Wave one</small></header>
+              <h3>Science &amp; discovery</h3>
+              <p>Track R&amp;D investment, research concentration, open data and software, replication, clinical translation, drug-development time, public research capacity, and whether AI measurably accelerates discovery rather than merely increasing publication volume.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>08</span><small>Planned</small></header>
+              <h3>Education &amp; human capability</h3>
+              <p>Track foundational literacy and numeracy, learning loss, vocational pathways, adult retraining, education costs, teacher shortages, skill mismatches, and whether AI tutors improve outcomes.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>09</span><small>Planned</small></header>
+              <h3>Financial fragility</h3>
+              <p>Track household debt, government interest burden, credit stress, savings, asset-price-to-income ratios, bank stability, pension adequacy, and who is exposed when rates or prices move.</p>
+            </div>
+          </li>
+          <li class="atlas-card" data-status="planned">
+            <div>
+              <header><span>10</span><small>Planned</small></header>
+              <h3>Global resilience</h3>
+              <p>Track conflict, displacement, food and energy exposure, supply-chain concentration, critical minerals, semiconductor dependencies, disaster losses, insurance retreat, and adaptation investment.</p>
+            </div>
+          </li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="publication-path" aria-labelledby="path-title">
+      <div class="atlas-shell">
+        <div class="section-head"><p class="section-label">Preferred first publication wave</p><h2 id="path-title">Build depth before breadth.</h2></div>
+        <p class="path-note">This six-topic first wave preserves the preferred order. Democracy, Education, Financial fragility and Global resilience remain part of the complete atlas and follow as evidence capacity allows.</p>
+        <ol>
+          <li class="done"><span>01</span><strong>Housing</strong><small>Published</small></li>
+          <li><span>02</span><strong>Prosperity</strong><small>Next</small></li>
+          <li><span>03</span><strong>Energy &amp; Compute</strong><small>Queued</small></li>
+          <li><span>04</span><strong>Healthspan</strong><small>Queued</small></li>
+          <li><span>05</span><strong>Demography</strong><small>Queued</small></li>
+          <li><span>06</span><strong>Science</strong><small>Queued</small></li>
+        </ol>
+      </div>
+    </section>
+
+    <section class="possibility-standard" aria-labelledby="possibility-title">
+      <div class="atlas-shell atlas-two-column">
+        <div>
+          <p class="section-label">The distinctive final chapter</p>
+          <h2 id="possibility-title">What might this make possible?</h2>
+        </div>
+        <div class="possibility-copy">
+          <p>Not investment advice and not optimism pasted over bad news. Every brief ends with explicitly labelled hypotheses about:</p>
+          <ul>
+            <li>Problems becoming more urgent</li>
+            <li>Capabilities becoming newly possible</li>
+            <li>Institutions or products society will need</li>
+            <li>Small interventions with disproportionate leverage</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="published-foundations" aria-labelledby="foundation-title">
+      <div class="atlas-shell">
+        <div class="section-head"><p class="section-label">Published foundations</p><h2 id="foundation-title">The experiment is already live.</h2></div>
+        <div class="foundation-grid">
+          <a href="../"><span>Brief 001</span><h3>AI &amp; work</h3><p>Observed labour markets, exposure, experiments, adoption and forecasts kept analytically separate.</p><strong>Open →</strong></a>
+          <a href="../food/"><span>Brief 002</span><h3>Food, animals &amp; planet</h3><p>Lives, land, emissions, forests, water, oceans and health with system boundaries intact.</p><strong>Open →</strong></a>
+          <a href="../housing/"><span>Brief 003</span><h3>Housing &amp; affordability</h3><p>Prices, incomes, rents, financing, tenure, supply and household formation across three lenses.</p><strong>Open →</strong></a>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="atlas-footer">
+    <div class="atlas-shell"><a href="../../">CTW Studio</a><span>Evidence over headlines</span><a href="#main-content">Back to top ↑</a></div>
+  </footer>
+  <script src="../../feedback.js"></script>
+</body>
+</html>

--- a/ctw.studio/signals/roadmap/roadmap.css
+++ b/ctw.studio/signals/roadmap/roadmap.css
@@ -1,0 +1,136 @@
+:root {
+  --atlas-bg: #080907;
+  --atlas-paper: #eeeee7;
+  --atlas-muted: #989e93;
+  --atlas-faint: #656b62;
+  --atlas-line: rgba(238,238,231,.13);
+  --atlas-green: #bad99f;
+  --atlas-gold: #e9ad63;
+  --atlas-blue: #85bce3;
+  --atlas-mono: "DM Mono", ui-monospace, monospace;
+}
+
+.roadmap-page,
+.roadmap-page body { margin: 0; background: var(--atlas-bg); color: var(--atlas-paper); font-family: Inter, system-ui, sans-serif; }
+.roadmap-page * { box-sizing: border-box; }
+.roadmap-page body::before { position: fixed; inset: 0; z-index: -1; content: ""; pointer-events: none; background: radial-gradient(circle at 82% 8%, rgba(186,217,159,.08), transparent 33rem), linear-gradient(rgba(255,255,255,.015) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.015) 1px, transparent 1px); background-size: auto, 52px 52px, 52px 52px; }
+.atlas-shell { width: min(1160px, calc(100% - 48px)); margin-inline: auto; }
+.atlas-hero { padding: 118px 0 90px; border-bottom: 1px solid var(--atlas-line); }
+.atlas-topics { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; padding-bottom: 78px; }
+.atlas-topics > span { flex: 0 0 auto; margin-right: 3px; color: var(--atlas-faint); font: 500 10px/1 var(--atlas-mono); letter-spacing: .12em; text-transform: uppercase; }
+.atlas-topics a { flex: 0 0 auto; padding: 8px 12px; border: 1px solid var(--atlas-line); border-radius: 99px; color: var(--atlas-muted); font: 500 10px/1 var(--atlas-mono); text-decoration: none; }
+.atlas-topics a:hover,
+.atlas-topics a:focus-visible { color: var(--atlas-paper); border-color: rgba(238,238,231,.3); }
+.atlas-topics .active { color: var(--atlas-green); border-color: rgba(186,217,159,.42); background: rgba(186,217,159,.07); }
+.atlas-kicker,
+.section-label { margin: 0 0 22px; color: var(--atlas-green); font: 500 10px/1 var(--atlas-mono); letter-spacing: .13em; text-transform: uppercase; }
+.atlas-hero h1 { max-width: 1000px; margin: 0; font-size: clamp(53px, 8.2vw, 112px); line-height: .92; letter-spacing: -.07em; }
+.atlas-hero h1 em { color: var(--atlas-green); font-family: Georgia, serif; font-weight: 400; }
+.atlas-deck { max-width: 720px; margin: 35px 0 0; color: #bec2b9; font-size: clamp(17px, 1.7vw, 21px); line-height: 1.6; }
+.atlas-status { display: flex; flex-wrap: wrap; gap: 10px 30px; margin-top: 47px; padding-top: 25px; border-top: 1px solid var(--atlas-line); color: var(--atlas-faint); font: 400 10px/1 var(--atlas-mono); text-transform: uppercase; }
+.atlas-status strong { margin-right: 4px; color: var(--atlas-paper); font-size: 17px; }
+.atlas-standard,
+.atlas-lenses,
+.atlas-topics-section,
+.publication-path,
+.possibility-standard,
+.published-foundations { padding: 110px 0; border-bottom: 1px solid var(--atlas-line); }
+.atlas-two-column { display: grid; grid-template-columns: .85fr 1.15fr; gap: clamp(60px, 10vw, 150px); align-items: start; }
+.standard-copy h2,
+.section-head h2,
+.possibility-standard h2 { margin: 0; font-size: clamp(38px, 5.2vw, 64px); line-height: 1.04; letter-spacing: -.052em; }
+.standard-copy > p:last-child,
+.topics-head > p { margin: 25px 0 0; color: var(--atlas-muted); font-size: 16px; line-height: 1.65; }
+.standard-questions { margin: 0; padding: 0; border-top: 1px solid var(--atlas-line); list-style: none; }
+.standard-questions li { display: grid; grid-template-columns: 54px 1fr; align-items: center; min-height: 74px; border-bottom: 1px solid var(--atlas-line); }
+.standard-questions span { color: var(--atlas-green); font: 500 10px/1 var(--atlas-mono); }
+.standard-questions strong { font-size: 16px; font-weight: 550; }
+.section-head { margin-bottom: 55px; }
+.lens-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; background: var(--atlas-line); }
+.lens-grid article { min-height: 280px; padding: 31px; background: #10110e; }
+.lens-grid span,
+.atlas-card header span,
+.atlas-card header small,
+.foundation-grid > a > span { color: var(--atlas-green); font: 500 9px/1.3 var(--atlas-mono); letter-spacing: .07em; text-transform: uppercase; }
+.lens-grid h3 { margin: 62px 0 15px; font-size: 24px; letter-spacing: -.035em; }
+.lens-grid p { margin: 0; color: var(--atlas-muted); font-size: 14px; line-height: 1.65; }
+.topics-head { display: grid; grid-template-columns: 1fr 380px; gap: 60px; align-items: end; }
+.topics-head > p { margin: 0; }
+.atlas-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin: 0; padding: 0; list-style: none; }
+.atlas-card { min-height: 335px; border: 1px solid var(--atlas-line); background: rgba(15,17,14,.76); }
+.atlas-card > div,
+.atlas-card > a { display: flex; flex-direction: column; min-height: 100%; padding: 32px; color: inherit; text-decoration: none; }
+.atlas-card header { display: flex; justify-content: space-between; gap: 20px; }
+.atlas-card header small { color: var(--atlas-faint); }
+.atlas-card h3 { margin: 58px 0 15px; font-size: 28px; letter-spacing: -.04em; }
+.atlas-card p { margin: 0; color: var(--atlas-muted); font-size: 14px; line-height: 1.67; }
+.atlas-card strong { display: block; margin-top: auto; padding-top: 27px; color: var(--atlas-green); font: 500 10px/1 var(--atlas-mono); text-transform: uppercase; }
+.atlas-card--published { border-color: rgba(186,217,159,.38); background: linear-gradient(145deg, rgba(186,217,159,.08), rgba(15,17,14,.8)); }
+.atlas-card--published > a:hover { background: rgba(186,217,159,.035); }
+.path-note { max-width: 760px; margin: 22px 0 34px; color: var(--atlas-muted); font-size: 15px; line-height: 1.65; }
+.publication-path ol { display: grid; grid-template-columns: repeat(6, 1fr); margin: 0; padding: 0; border: solid var(--atlas-line); border-width: 1px 0; list-style: none; }
+.publication-path li { display: grid; min-height: 150px; padding: 23px 18px; border-right: 1px solid var(--atlas-line); }
+.publication-path li:last-child { border-right: 0; }
+.publication-path span { color: var(--atlas-faint); font: 500 9px/1 var(--atlas-mono); }
+.publication-path strong { align-self: end; font-size: 14px; }
+.publication-path small { margin-top: 7px; color: var(--atlas-faint); font: 400 8px/1 var(--atlas-mono); text-transform: uppercase; }
+.publication-path .done { background: rgba(186,217,159,.06); }
+.publication-path .done span,
+.publication-path .done small { color: var(--atlas-green); }
+.possibility-standard { background: rgba(186,217,159,.025); }
+.possibility-copy > p { margin: 0 0 25px; color: var(--atlas-muted); font-size: 16px; line-height: 1.65; }
+.possibility-copy ul { display: grid; gap: 0; margin: 0; padding: 0; border-top: 1px solid var(--atlas-line); list-style: none; }
+.possibility-copy li { padding: 17px 0; border-bottom: 1px solid var(--atlas-line); color: var(--atlas-paper); font-size: 14px; }
+.possibility-copy li::before { margin-right: 12px; color: var(--atlas-green); content: "→"; }
+.foundation-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 12px; }
+.foundation-grid a { display: flex; flex-direction: column; min-height: 270px; padding: 28px; border: 1px solid var(--atlas-line); color: inherit; text-decoration: none; }
+.foundation-grid h3 { margin: 55px 0 12px; font-size: 23px; }
+.foundation-grid p { margin: 0; color: var(--atlas-muted); font-size: 13px; line-height: 1.6; }
+.foundation-grid strong { margin-top: auto; padding-top: 20px; color: var(--atlas-green); font: 500 9px/1 var(--atlas-mono); text-transform: uppercase; }
+.foundation-grid a:hover { border-color: rgba(186,217,159,.5); }
+.roadmap-page .ctw-feedback-button { transform: scale(.82) !important; transform-origin: right bottom !important; }
+.atlas-footer { padding: 30px 0; background: #050604; }
+.atlas-footer .atlas-shell { display: flex; justify-content: space-between; gap: 20px; color: var(--atlas-faint); font: 400 9px/1 var(--atlas-mono); text-transform: uppercase; }
+.atlas-footer a { color: var(--atlas-muted); text-decoration: none; }
+.atlas-footer a:hover { color: var(--atlas-green); }
+
+@media (max-width: 900px) {
+  .atlas-two-column,
+  .topics-head { grid-template-columns: 1fr; gap: 55px; }
+  .topics-head > p { max-width: 650px; }
+  .publication-path ol { grid-template-columns: repeat(3, 1fr); }
+  .publication-path li:nth-child(3) { border-right: 0; }
+  .publication-path li:nth-child(-n+3) { border-bottom: 1px solid var(--atlas-line); }
+  .foundation-grid { grid-template-columns: 1fr; }
+  .foundation-grid a { min-height: 230px; }
+}
+
+@media (max-width: 650px) {
+  .roadmap-page .ctw-feedback-button { transform: scale(.68) !important; right: 10px !important; bottom: 10px !important; }
+  .atlas-shell { width: min(100% - 30px, 1160px); }
+  .atlas-hero { padding-top: 104px; }
+  .atlas-topics { padding-bottom: 58px; }
+  .atlas-hero h1 { font-size: clamp(50px, 15vw, 76px); }
+  .atlas-standard,
+  .atlas-lenses,
+  .atlas-topics-section,
+  .publication-path,
+  .possibility-standard,
+  .published-foundations { padding: 78px 0; }
+  .lens-grid,
+  .atlas-grid { grid-template-columns: 1fr; }
+  .lens-grid article { min-height: 230px; }
+  .atlas-card { min-height: 0; }
+  .atlas-card > div,
+  .atlas-card > a { padding: 25px; }
+  .atlas-card h3 { margin-top: 43px; }
+  .publication-path ol { grid-template-columns: repeat(2, 1fr); }
+  .publication-path li:nth-child(3) { border-right: 1px solid var(--atlas-line); }
+  .publication-path li:nth-child(even) { border-right: 0; }
+  .publication-path li:nth-child(-n+4) { border-bottom: 1px solid var(--atlas-line); }
+  .atlas-footer .atlas-shell { flex-direction: column; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .roadmap-page * { scroll-behavior: auto !important; }
+}

--- a/ctw.studio/signals/scripts/update_food_data.py
+++ b/ctw.studio/signals/scripts/update_food_data.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Refresh updateable global food-system observations baked into food-system.json.
+
+Sources:
+- FAOSTAT data republished through the Our World in Data grapher
+- Poore & Nemecek (2018) product footprints republished through OWID
+
+No credentials are required. Curated interpretation and slow-moving assessment values
+remain deliberately review-gated in the JSON file.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import subprocess
+from datetime import date
+from pathlib import Path
+
+DATA_PATH = Path(__file__).resolve().parents[1] / "data" / "food-system.json"
+SLAUGHTER_URL = "https://ourworldindata.org/grapher/animals-slaughtered-for-meat.csv"
+FOOTPRINT_URL = "https://ourworldindata.org/grapher/food-emissions-supply-chain.csv"
+
+SPECIES = ["Chicken", "Duck", "Pig", "Sheep", "Goat", "Turkey", "Cattle"]
+PRODUCTS = [
+    "Beef (beef herd)",
+    "Lamb & Mutton",
+    "Fish (farmed)",
+    "Pig Meat",
+    "Poultry Meat",
+    "Tofu",
+    "Peas",
+]
+
+
+def fetch_text(url: str) -> str:
+    result = subprocess.run(
+        [
+            "curl",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--retry",
+            "3",
+            "--retry-delay",
+            "2",
+            url,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout
+
+
+def is_leap(year: int) -> bool:
+    return year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+
+
+def refresh_slaughter(data: dict) -> None:
+    rows = list(csv.DictReader(io.StringIO(fetch_text(SLAUGHTER_URL))))
+    world = [row for row in rows if row.get("Entity") == "World"]
+    if not world:
+        raise RuntimeError("No World observations in slaughter dataset")
+
+    latest_year = max(int(row["Year"]) for row in world)
+    row = next(row for row in world if int(row["Year"]) == latest_year)
+    missing = [species for species in SPECIES if not row.get(species)]
+    if missing:
+        raise RuntimeError(f"Missing slaughter columns for {', '.join(missing)}")
+
+    days = 366 if is_leap(latest_year) else 365
+    species_rows = []
+    for species in SPECIES:
+        annual = int(float(row[species]))
+        species_rows.append(
+            {
+                "name": species,
+                "annual": annual,
+                "daily": round(annual / days),
+            }
+        )
+
+    annual_total = sum(item["annual"] for item in species_rows)
+    species_rows.sort(key=lambda item: item["annual"], reverse=True)
+    data["slaughter"].update(
+        {
+            "year": latest_year,
+            "daysInYear": days,
+            "speciesIncluded": SPECIES,
+            "annualTracked": annual_total,
+            "dailyTracked": round(annual_total / days),
+            "perMinuteTracked": round(annual_total / days / 24 / 60),
+            "species": species_rows,
+        }
+    )
+
+
+def refresh_footprints(data: dict) -> None:
+    rows = list(csv.DictReader(io.StringIO(fetch_text(FOOTPRINT_URL))))
+    by_product = {row["Entity"]: row for row in rows}
+    missing = [name for name in PRODUCTS if name not in by_product]
+    if missing:
+        raise RuntimeError(f"Missing footprint rows for {', '.join(missing)}")
+
+    footprints = []
+    for name in PRODUCTS:
+        row = by_product[name]
+        total = sum(
+            float(value)
+            for key, value in row.items()
+            if key not in {"Entity", "Year"} and value
+        )
+        footprints.append(
+            {
+                "product": name,
+                "year": int(row["Year"]),
+                "kgCO2ePerKgFood": round(total, 2),
+            }
+        )
+    data["productFootprints"] = footprints
+
+
+def main() -> None:
+    data = json.loads(DATA_PATH.read_text())
+    refresh_slaughter(data)
+    refresh_footprints(data)
+    data["meta"]["dataUpdated"] = date.today().isoformat()
+    DATA_PATH.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    print(
+        "Updated food-system.json: "
+        f"{data['slaughter']['year']} slaughter counts, "
+        f"{len(data['productFootprints'])} product footprints"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ctw.studio/signals/scripts/update_fred.py
+++ b/ctw.studio/signals/scripts/update_fred.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Refresh the live BLS/FRED series used by the AI-and-jobs dashboard.
+
+The script deliberately updates only official monthly time series and derived
+headline values. Curated research evidence in data/ai-jobs.json remains manual
+because exposure studies, working papers, and forecasts require source review.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import subprocess
+from datetime import date
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = ROOT / "data" / "ai-jobs.json"
+START_DATE = "2020-01-01"
+CHATGPT_BASELINE = "2022-11-01"
+KNOWN_UNAVAILABLE = {
+    "UNRATE": {
+        "2025-10-01": "Data unavailable due to the 2025 lapse in appropriations.",
+    }
+}
+
+SERIES = {
+    "openings": {
+        "fredId": "JTSJOL",
+        "label": "Job openings",
+        "shortLabel": "Openings",
+        "unit": "million",
+        "decimals": 3,
+        "divisor": 1000,
+        "sourceId": "fred-jolts",
+        "definition": "Seasonally adjusted total nonfarm job openings in the United States.",
+    },
+    "hires": {
+        "fredId": "JTSHIL",
+        "label": "Hires",
+        "shortLabel": "Hires",
+        "unit": "million",
+        "decimals": 3,
+        "divisor": 1000,
+        "sourceId": "fred-jolts",
+        "definition": "Seasonally adjusted total nonfarm hires in the United States.",
+    },
+    "unemployment": {
+        "fredId": "UNRATE",
+        "label": "Unemployment rate",
+        "shortLabel": "Unemployment",
+        "unit": "percent",
+        "decimals": 1,
+        "divisor": 1,
+        "sourceId": "fred-unrate",
+        "definition": "Seasonally adjusted U.S. civilian unemployment rate.",
+    },
+}
+
+
+def monthly_dates(start: str, end: str) -> list[str]:
+    cursor = date.fromisoformat(start)
+    final = date.fromisoformat(end)
+    months = []
+    while cursor <= final:
+        months.append(cursor.isoformat())
+        cursor = date(cursor.year + (cursor.month == 12), cursor.month % 12 + 1, 1)
+    return months
+
+
+def validate_monthly_series(fred_id: str, observations: list[dict]) -> list[dict]:
+    dates = [item["date"] for item in observations]
+    if dates != sorted(set(dates)):
+        raise RuntimeError(f"{fred_id} dates are duplicated or out of order")
+
+    expected = set(monthly_dates(dates[0], dates[-1]))
+    missing = expected - set(dates)
+    documented = set(KNOWN_UNAVAILABLE.get(fred_id, {})) & expected
+    undocumented = missing - documented
+    unexpectedly_present = documented - missing
+    if undocumented:
+        raise RuntimeError(
+            f"{fred_id} has undocumented missing months: {', '.join(sorted(undocumented))}"
+        )
+    if unexpectedly_present:
+        raise RuntimeError(
+            f"{fred_id} now publishes formerly unavailable months: "
+            f"{', '.join(sorted(unexpectedly_present))}; review the exception list"
+        )
+
+    return [
+        {"date": missing_date, "reason": KNOWN_UNAVAILABLE[fred_id][missing_date]}
+        for missing_date in sorted(missing)
+    ]
+
+
+def download_series(
+    fred_id: str, divisor: float, decimals: int
+) -> tuple[list[dict], list[dict]]:
+    url = f"https://fred.stlouisfed.org/graph/fredgraph.csv?id={fred_id}"
+    result = subprocess.run(
+        [
+            "curl",
+            "--fail",
+            "--silent",
+            "--show-error",
+            "--location",
+            "--retry",
+            "3",
+            "--connect-timeout",
+            "20",
+            "--max-time",
+            "120",
+            url,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    text = result.stdout
+
+    observations = []
+    for row in csv.DictReader(io.StringIO(text)):
+        raw = row.get(fred_id)
+        observation_date = row.get("observation_date", "")
+        if not raw or raw == "." or observation_date < START_DATE:
+            continue
+        observations.append(
+            {
+                "date": observation_date,
+                "value": round(float(raw) / divisor, decimals),
+            }
+        )
+
+    if not observations:
+        raise RuntimeError(f"FRED returned no usable observations for {fred_id}")
+    unavailable = validate_monthly_series(fred_id, observations)
+    return observations, unavailable
+
+
+def observation_on(series: list[dict], wanted_date: str) -> dict:
+    try:
+        return next(item for item in series if item["date"] == wanted_date)
+    except StopIteration as exc:
+        raise RuntimeError(f"Series is missing required baseline {wanted_date}") from exc
+
+
+def percent_change(start: float, end: float) -> float:
+    return round(((end - start) / start) * 100, 1)
+
+
+def main() -> None:
+    data = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    refreshed = {}
+
+    for key, config in SERIES.items():
+        observations, unavailable = download_series(
+            config["fredId"], config["divisor"], config["decimals"]
+        )
+        refreshed[key] = {
+            field: value
+            for field, value in config.items()
+            if field not in {"divisor", "decimals"}
+        }
+        refreshed[key]["observations"] = observations
+        refreshed[key]["unavailable"] = unavailable
+        refreshed[key]["latest"] = observations[-1]
+
+    openings = refreshed["openings"]["observations"]
+    hires = refreshed["hires"]["observations"]
+    unemployment = refreshed["unemployment"]["observations"]
+    openings_baseline = observation_on(openings, CHATGPT_BASELINE)
+    unemployment_baseline = observation_on(unemployment, CHATGPT_BASELINE)
+    pre_chatgpt_peak = max(
+        (item for item in openings if item["date"] <= CHATGPT_BASELINE),
+        key=lambda item: item["value"],
+    )
+
+    data["series"] = refreshed
+    data["headline"] = {
+        "chatgptBaseline": CHATGPT_BASELINE,
+        "openingsAtBaseline": openings_baseline,
+        "openingsLatest": refreshed["openings"]["latest"],
+        "openingsChangeSinceBaselinePct": percent_change(
+            openings_baseline["value"], refreshed["openings"]["latest"]["value"]
+        ),
+        "preChatgptOpeningsPeak": pre_chatgpt_peak,
+        "openingsChangeFromPreChatgptPeakPct": percent_change(
+            pre_chatgpt_peak["value"], refreshed["openings"]["latest"]["value"]
+        ),
+        "hiresLatest": refreshed["hires"]["latest"],
+        "unemploymentAtBaseline": unemployment_baseline,
+        "unemploymentLatest": refreshed["unemployment"]["latest"],
+        "unemploymentChangeSinceBaselinePoints": round(
+            refreshed["unemployment"]["latest"]["value"]
+            - unemployment_baseline["value"],
+            1,
+        ),
+    }
+    data["meta"]["seriesUpdated"] = date.today().isoformat()
+    DATA_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    print(f"Updated {DATA_PATH}")
+    for key, series in refreshed.items():
+        latest = series["latest"]
+        print(f"  {key}: {latest['value']} ({latest['date']})")
+
+
+if __name__ == "__main__":
+    main()

--- a/ctw.studio/signals/scripts/update_housing_data.py
+++ b/ctw.studio/signals/scripts/update_housing_data.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+"""Refresh the baked official observations for Housing & affordability (Brief 003).
+
+No credentials are required. The script updates only quantitative observations;
+editorial interpretation, caveats, country-selection rationale and source roles
+remain review-gated in data/housing.json.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import itertools
+import json
+import subprocess
+from datetime import date
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlencode
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_PATH = ROOT / "data" / "housing.json"
+
+OECD_URL = (
+    "https://sdmx.oecd.org/public/rest/v1/data/"
+    "OECD.ECO.MPD,DSD_AN_HOUSE_PRICES@DF_HOUSE_PRICES,1.0/.?startPeriod=2010-Q1"
+)
+ECB_URL = (
+    "https://data-api.ecb.europa.eu/service/data/"
+    "MIR/M.NL.B.A2C.A.R.A.2250.EUR.N"
+    "?startPeriod=2015-01&format=csvdata&detail=dataonly"
+)
+CBS_BASE = "https://opendata.cbs.nl/ODataApi/OData"
+WORLD_BANK_BASE = "https://api.worldbank.org/v2/country/WLD/indicator"
+EUROSTAT_BASE = "https://ec.europa.eu/eurostat/api/dissemination/statistics/1.0/data"
+
+COUNTRIES = {
+    "NLD": ("Netherlands", "Primary context: rapid post-2015 deterioration despite a large regulated-rental sector."),
+    "DEU": ("Germany", "A renter-majority contrast with a smaller post-2015 price-to-income shift."),
+    "ESP": ("Spain", "A high-ownership market shaped by a different construction cycle after the euro-area housing crash."),
+    "CAN": ("Canada", "A non-European high-income market with strong population growth and pronounced urban supply pressure."),
+    "JPN": ("Japan", "An aging-country contrast where national abundance can coexist with scarcity in the largest cities."),
+    "AUT": ("Austria", "A European contrast with substantial social and limited-profit housing, especially in Vienna."),
+}
+
+OECD_MEASURES = {
+    "housePrice": ("HPI", "House-price index"),
+    "rentPrice": ("RPI", "Rent-price index"),
+    "priceToIncome": ("HPI_YDH", "Price-to-income index"),
+    "priceToRent": ("HPI_RPI", "Price-to-rent index"),
+}
+
+TENURE_LABELS = {
+    "OWN_L": "Owner with mortgage",
+    "OWN_NL": "Owner without mortgage",
+    "RENT_MKT": "Market-rate tenant",
+    "RENT_FR": "Reduced/free-rent tenant",
+}
+
+
+def fetch_text(url: str, accept: str | None = None) -> str:
+    command = [
+        "curl",
+        "--fail",
+        "--silent",
+        "--show-error",
+        "--location",
+        "--retry",
+        "3",
+        "--retry-delay",
+        "2",
+        "--connect-timeout",
+        "20",
+        "--max-time",
+        "180",
+    ]
+    if accept:
+        command.extend(["--header", f"Accept: {accept}"])
+    command.append(url)
+    result = subprocess.run(command, check=True, capture_output=True, text=True)
+    if not result.stdout.strip():
+        raise RuntimeError(f"Empty response from {url}")
+    return result.stdout
+
+
+def fetch_json(url: str) -> Any:
+    return json.loads(fetch_text(url, "application/json"))
+
+
+def round1(value: str | float) -> float:
+    return round(float(value), 1)
+
+
+def parse_eurostat(dataset: str, filters: dict[str, str | list[str]]) -> list[dict]:
+    payload = fetch_json(f"{EUROSTAT_BASE}/{dataset}?{urlencode(filters, doseq=True)}")
+    dimensions = payload["id"]
+    sizes = payload["size"]
+    categories = []
+    for dimension in dimensions:
+        indexes = payload["dimension"][dimension]["category"]["index"]
+        ordered = [None] * len(indexes)
+        for code, position in indexes.items():
+            ordered[position] = code
+        categories.append(ordered)
+
+    rows = []
+    for coordinates in itertools.product(*[range(size) for size in sizes]):
+        flat_index = 0
+        for coordinate, size in zip(coordinates, sizes):
+            flat_index = flat_index * size + coordinate
+        raw_value = payload.get("value", {}).get(str(flat_index))
+        if raw_value is None:
+            continue
+        row = {
+            dimensions[index]: categories[index][coordinates[index]]
+            for index in range(len(dimensions))
+        }
+        row["value"] = float(raw_value)
+        rows.append(row)
+    if not rows:
+        raise RuntimeError(f"Eurostat returned no observations for {dataset}")
+    return rows
+
+
+def latest_non_null_world_bank(indicator: str) -> dict:
+    payload = fetch_json(f"{WORLD_BANK_BASE}/{indicator}?format=json&per_page=100")
+    if not isinstance(payload, list) or len(payload) < 2:
+        raise RuntimeError(f"Unexpected World Bank response for {indicator}")
+    for observation in payload[1]:
+        if observation.get("value") is not None:
+            return {"period": observation["date"], "value": float(observation["value"])}
+    raise RuntimeError(f"World Bank returned no usable observations for {indicator}")
+
+
+def refresh_world(data: dict) -> None:
+    slum_share = latest_non_null_world_bank("EN.POP.SLUM.UR.ZS")
+    urban_population_payload = fetch_json(
+        f"{WORLD_BANK_BASE}/SP.URB.TOTL?format=json&per_page=100"
+    )
+    urban_by_year = {
+        row["date"]: float(row["value"])
+        for row in urban_population_payload[1]
+        if row.get("value") is not None
+    }
+    urban_population = urban_by_year.get(slum_share["period"])
+    if urban_population is None:
+        raise RuntimeError("World Bank urban-population series lacks the slum-share year")
+    estimated_people_millions = slum_share["value"] / 100 * urban_population / 1_000_000
+
+    data["world"]["slumShare"] = {
+        "value": round1(slum_share["value"]),
+        "rawValue": slum_share["value"],
+        "unit": "% of urban population",
+        "period": slum_share["period"],
+        "sourceId": "world-bank-slums",
+    }
+    data["world"]["urbanPopulation"] = {
+        "valueBillions": round(urban_population / 1_000_000_000, 2),
+        "valuePeople": urban_population,
+        "period": slum_share["period"],
+        "sourceId": "world-bank-slums",
+    }
+    data["world"]["estimatedPeople"] = {
+        "valueMillions": round(estimated_people_millions),
+        "period": slum_share["period"],
+        "derived": True,
+        "note": "Derived from unrounded source values: the World Bank/UN-Habitat slum share and World Bank urban-population observation for the same year. It is not a direct census count.",
+        "sourceId": "world-bank-slums",
+    }
+
+
+def refresh_oecd(data: dict) -> None:
+    rows = list(csv.DictReader(io.StringIO(fetch_text(OECD_URL, "text/csv"))))
+    if not rows:
+        raise RuntimeError("OECD returned no analytical house-price observations")
+
+    netherlands = data["netherlands"].setdefault("oecd", {})
+    for key, (measure, label) in OECD_MEASURES.items():
+        observations = [
+            {"period": row["TIME_PERIOD"], "value": round1(row["OBS_VALUE"])}
+            for row in rows
+            if row["REF_AREA"] == "NLD"
+            and row["FREQ"] == "Q"
+            and row["MEASURE"] == measure
+            and row["UNIT_MEASURE"] == "IX"
+        ]
+        observations.sort(key=lambda item: item["period"])
+        if len(observations) < 40:
+            raise RuntimeError(f"OECD {measure} history is unexpectedly short")
+        netherlands[key] = {
+            "measure": measure,
+            "label": label,
+            "base": "2015=100",
+            "frequency": "Quarterly, seasonally adjusted",
+            "observations": observations,
+            "latest": observations[-1],
+            "sourceId": "oecd-house-prices",
+        }
+
+    availability = {}
+    for code in COUNTRIES:
+        availability[code] = {
+            row["TIME_PERIOD"]
+            for row in rows
+            if row["REF_AREA"] == code
+            and row["FREQ"] == "Q"
+            and row["MEASURE"] == "HPI_YDH"
+            and row["UNIT_MEASURE"] == "IX"
+        }
+    common_periods = set.intersection(*availability.values())
+    comparison_period = max(common_periods)
+    comparisons = []
+    for code, (name, rationale) in COUNTRIES.items():
+        row = next(
+            item
+            for item in rows
+            if item["REF_AREA"] == code
+            and item["FREQ"] == "Q"
+            and item["MEASURE"] == "HPI_YDH"
+            and item["TIME_PERIOD"] == comparison_period
+        )
+        comparisons.append(
+            {
+                "code": code,
+                "name": name,
+                "value": round1(row["OBS_VALUE"]),
+                "whyIncluded": rationale,
+            }
+        )
+    data["comparisons"]["period"] = comparison_period
+    data["comparisons"]["countries"] = comparisons
+
+
+def refresh_cbs(data: dict) -> None:
+    existing_rows = fetch_json(f"{CBS_BASE}/85773ENG/TypedDataSet")["value"]
+    monthly = []
+    for row in existing_rows:
+        raw_period = row.get("Periods", "")
+        if len(raw_period) != 8 or "MM" not in raw_period or raw_period[:4] < "2015":
+            continue
+        monthly.append(
+            {
+                "period": f"{raw_period[:4]}-{raw_period[-2:]}",
+                "priceIndex2020": round1(row["PriceIndexSellingPrices_1"]),
+                "yearOnYearPct": round1(row["ChangesComparedToThePreviousYear_3"]),
+                "soldHomes": row["SoldHomes_4"],
+                "averagePurchasePriceEur": row["AveragePurchasePrice_7"],
+            }
+        )
+    monthly.sort(key=lambda item: item["period"])
+    if len(monthly) < 100:
+        raise RuntimeError("CBS existing-home monthly history is unexpectedly short")
+    data["netherlands"]["cbs"]["existingHomes"] = {
+        "observations": monthly,
+        "latest": monthly[-1],
+        "sourceId": "cbs-existing-homes",
+        "note": "Average purchase price is descriptive and is not corrected for changes in the mix of homes sold; the price index is the quality-adjusted measure.",
+    }
+
+    stock_rows = fetch_json(f"{CBS_BASE}/82235NED/TypedDataSet")["value"]
+    household_rows = fetch_json(
+        f"{CBS_BASE}/71486NED/TypedDataSet?"
+        "$filter=RegioS%20eq%20%27NL01%20%20%27%20and%20"
+        "LeeftijdReferentiepersoon%20eq%20%2710000%27"
+    )["value"]
+    stock_by_year = {
+        int(row["Perioden"][:4]): row
+        for row in stock_rows
+        if row.get("Perioden", "")[:4].isdigit() and int(row["Perioden"][:4]) >= 2015
+    }
+    households_by_year = {
+        int(row["Perioden"][:4]): int(row["TotaalParticuliereHuishoudens_1"])
+        for row in household_rows
+        if row.get("Perioden", "")[:4].isdigit() and int(row["Perioden"][:4]) >= 2015
+    }
+    aligned = []
+    for year in sorted(stock_by_year):
+        if year < 2018:
+            continue
+        if year not in households_by_year or year + 1 not in households_by_year:
+            continue
+        stock = stock_by_year[year]
+        start = households_by_year[year]
+        end = households_by_year[year + 1]
+        aligned.append(
+            {
+                "year": year,
+                "newConstruction": int(stock["Nieuwbouw_2"]),
+                "netHousingAddition": int(stock["SaldoVoorraad_8"]),
+                "householdsStart": start,
+                "householdsEnd": end,
+                "householdGrowth": end - start,
+            }
+        )
+    if len(aligned) < 7:
+        raise RuntimeError("CBS housing/household alignment is unexpectedly short")
+    latest_stock = stock_by_year[max(stock_by_year)]
+    data["netherlands"]["supplyVsHouseholds"] = aligned
+    data["netherlands"]["latestSupply"] = {
+        "year": max(stock_by_year),
+        "newConstruction": int(latest_stock["Nieuwbouw_2"]),
+        "netHousingAddition": int(latest_stock["SaldoVoorraad_8"]),
+        "householdComparatorAvailable": max(stock_by_year) + 1 in households_by_year,
+        "sourceIds": ["cbs-housing-stock", "cbs-households"],
+        "note": "Households are measured on 1 January. Each aligned row compares stock change during the year with the change in private households from 1 January of that year to 1 January of the next.",
+    }
+
+
+def refresh_ecb(data: dict) -> None:
+    rows = list(csv.DictReader(io.StringIO(fetch_text(ECB_URL, "text/csv"))))
+    observations = [
+        {"period": row["TIME_PERIOD"], "value": round1(row["OBS_VALUE"])}
+        for row in rows
+        if row.get("OBS_VALUE")
+    ]
+    observations.sort(key=lambda item: item["period"])
+    if len(observations) < 100:
+        raise RuntimeError("ECB mortgage-rate history is unexpectedly short")
+    low = min(observations, key=lambda item: item["value"])
+    data["netherlands"]["ecbMortgage"] = {
+        "unit": "% per year",
+        "definition": "Annualised agreed rate on new euro-denominated loans to Dutch households for house purchase, all initial fixation periods.",
+        "observations": observations,
+        "latest": observations[-1],
+        "lowSince2015": low,
+        "sourceId": "ecb-mortgage",
+    }
+
+
+def refresh_eurostat(data: dict) -> None:
+    overburden = parse_eurostat(
+        "ilc_lvho07c", {"geo": "NL", "sinceTimePeriod": "2015"}
+    )
+    latest_period = max(row["time"] for row in overburden)
+    by_tenure = []
+    for code, label in TENURE_LABELS.items():
+        row = next(
+            item
+            for item in overburden
+            if item["time"] == latest_period and item["tenure"] == code
+        )
+        by_tenure.append({"code": code, "tenure": label, "value": round1(row["value"])})
+    total = next(
+        item
+        for item in overburden
+        if item["time"] == latest_period and item["tenure"] == "TOTAL"
+    )
+    data["netherlands"]["overburden"].update(
+        {
+            "period": latest_period,
+            "totalPct": round1(total["value"]),
+            "byTenure": by_tenure,
+            "sourceId": "eurostat-overburden",
+        }
+    )
+
+    tenure = parse_eurostat(
+        "ilc_lvho02",
+        {
+            "geo": ["NL", "EU27_2020"],
+            "rskpovth": "TOTAL",
+            "hhcomp": "TOTAL",
+            "sinceTimePeriod": "2015",
+        },
+    )
+    tenure_period = max(
+        set(row["time"] for row in tenure if row["geo"] == "NL")
+        & set(row["time"] for row in tenure if row["geo"] == "EU27_2020")
+    )
+    shares = {}
+    for geography in ["NL", "EU27_2020"]:
+        shares[geography] = {
+            row["tenure"]: round1(row["value"])
+            for row in tenure
+            if row["geo"] == geography
+            and row["time"] == tenure_period
+            and row["tenure"] in {"OWN", "RENT_MKT", "RENT_FR"}
+        }
+    data["netherlands"]["tenure"] = {
+        "period": tenure_period,
+        "shares": shares,
+        "sourceId": "eurostat-tenure",
+        "note": "Rent at reduced price or free includes social, subsidised and other below-market arrangements; categories are population shares, not dwelling-stock shares.",
+    }
+
+
+def validate(data: dict) -> None:
+    source_ids = {source["id"] for source in data["sources"]}
+    if len(source_ids) != len(data["sources"]):
+        raise RuntimeError("Duplicate source IDs")
+    if data["comparisons"]["period"] < "2025-Q1":
+        raise RuntimeError("Selected-country comparison is stale")
+    if data["netherlands"]["cbs"]["existingHomes"]["latest"]["period"] < "2026-01":
+        raise RuntimeError("CBS existing-home data is stale")
+    for source in data["sources"]:
+        if not source["url"].startswith("https://"):
+            raise RuntimeError(f"Non-HTTPS source URL: {source['id']}")
+
+
+def main() -> None:
+    data = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    refresh_world(data)
+    refresh_oecd(data)
+    refresh_cbs(data)
+    refresh_ecb(data)
+    refresh_eurostat(data)
+    data["meta"]["dataUpdated"] = date.today().isoformat()
+    for source in data["sources"]:
+        source["accessed"] = date.today().isoformat()
+    validate(data)
+    DATA_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False) + "\n", encoding="utf-8"
+    )
+
+    latest_home = data["netherlands"]["cbs"]["existingHomes"]["latest"]
+    affordability = data["netherlands"]["oecd"]["priceToIncome"]["latest"]
+    print(f"Updated {DATA_PATH}")
+    print(
+        f"  Dutch existing homes: {latest_home['yearOnYearPct']}% y/y "
+        f"({latest_home['period']})"
+    )
+    print(
+        f"  Price-to-income: {affordability['value']} "
+        f"({affordability['period']}, 2015=100)"
+    )
+    print(
+        f"  Comparison: {data['comparisons']['period']} across "
+        f"{len(data['comparisons']['countries'])} countries"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/ctw.studio/signals/signals.css
+++ b/ctw.studio/signals/signals.css
@@ -1,0 +1,408 @@
+:root {
+  color-scheme: dark;
+  --ink: #f4f1e8;
+  --ink-soft: #c3c0b8;
+  --muted: #8b8a84;
+  --coal: #050505;
+  --panel: #0c0c0b;
+  --panel-raised: #11110f;
+  --line: rgba(255, 255, 255, 0.11);
+  --line-strong: rgba(255, 255, 255, 0.2);
+  --amber: #f7b500;
+  --cyan: #57d7ff;
+  --coral: #ff6b5f;
+  --violet: #a58bff;
+  --green: #53d38b;
+  --mono: 'DM Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  --sans: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
+* { box-sizing: border-box; }
+html { scrollbar-gutter: stable; }
+body {
+  margin: 0;
+  overflow-x: hidden;
+  background:
+    radial-gradient(circle at 74% 3%, rgba(247, 181, 0, 0.09), transparent 27rem),
+    var(--coal);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; }
+button { font: inherit; }
+
+.skip-link {
+  position: fixed;
+  z-index: 100;
+  top: 0.75rem;
+  left: 0.75rem;
+  padding: 0.75rem 1rem;
+  transform: translateY(-150%);
+  border-radius: 999px;
+  background: var(--amber);
+  color: #000;
+  font-weight: 700;
+}
+.skip-link:focus { transform: translateY(0); }
+
+.signal-shell { width: min(1480px, calc(100% - 3rem)); margin-inline: auto; }
+.signal-hero { position: relative; padding: 9rem 0 4rem; border-bottom: 1px solid var(--line); }
+.signal-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255,255,255,0.025) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255,255,255,0.025) 1px, transparent 1px);
+  background-size: 56px 56px;
+  mask-image: linear-gradient(to bottom, #000, transparent 92%);
+}
+
+.topic-switcher {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  margin-bottom: clamp(3rem, 7vw, 6rem);
+  color: var(--muted);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.topic-switcher__label { margin-right: 0.7rem; color: var(--ink); font-weight: 500; }
+.topic-pill { padding: 0.42rem 0.75rem; border: 1px solid var(--line); border-radius: 999px; text-decoration: none; }
+.topic-pill--active { border-color: rgba(247,181,0,0.45); background: rgba(247,181,0,0.09); color: var(--amber); }
+.topic-pill--future span { margin-left: 0.35rem; color: var(--ink-soft); }
+
+.hero-grid { position: relative; display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(350px, 0.65fr); gap: clamp(3rem, 8vw, 8rem); align-items: end; }
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--amber);
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  font-weight: 500;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+.eyebrow span { display: inline-flex; align-items: center; gap: 0.4rem; }
+.eyebrow span::before { content: ''; width: 0.45rem; height: 0.45rem; border-radius: 50%; background: currentColor; box-shadow: 0 0 16px currentColor; }
+.eyebrow--observed { color: var(--cyan); }
+.eyebrow--exposure { color: var(--amber); }
+.eyebrow--forecast { color: var(--green); }
+.eyebrow--experiment { color: var(--violet); }
+.hero-copy h1 {
+  max-width: 980px;
+  margin: 0;
+  font-size: clamp(3.25rem, 7.1vw, 7.4rem);
+  font-weight: 700;
+  letter-spacing: -0.07em;
+  line-height: 0.94;
+}
+.hero-copy h1 em, .section-heading h2 em { color: var(--amber); font-style: normal; }
+.hero-deck { max-width: 850px; margin: 2rem 0 0; color: var(--ink-soft); font-size: clamp(1.05rem, 1.55vw, 1.35rem); line-height: 1.65; }
+.hero-deck strong { color: var(--ink); font-weight: 600; }
+.hero-meta { display: flex; flex-wrap: wrap; align-items: center; gap: 0.6rem; margin-top: 2rem; color: var(--muted); font-family: var(--mono); font-size: 0.71rem; }
+.hero-meta a { margin-left: 0.35rem; color: var(--ink-soft); text-underline-offset: 4px; }
+.live-dot { width: 0.5rem; height: 0.5rem; border-radius: 50%; background: var(--green); box-shadow: 0 0 12px rgba(83,211,139,0.75); }
+
+.verdict-card { position: relative; overflow: hidden; padding: 1.6rem; border: 1px solid rgba(247,181,0,0.27); border-radius: 1.4rem; background: linear-gradient(145deg, rgba(247,181,0,0.09), rgba(255,255,255,0.025)); box-shadow: 0 30px 90px rgba(0,0,0,0.35); }
+.verdict-card::after { content: ''; position: absolute; right: -35%; bottom: -55%; width: 80%; aspect-ratio: 1; border-radius: 50%; border: 1px solid rgba(247,181,0,0.14); box-shadow: 0 0 0 28px rgba(247,181,0,0.025), 0 0 0 56px rgba(247,181,0,0.018); }
+.verdict-card > * { position: relative; z-index: 1; }
+.verdict-card__topline { display: flex; justify-content: space-between; color: var(--muted); font-family: var(--mono); font-size: 0.67rem; text-transform: uppercase; }
+.verdict-status { color: var(--amber); }
+.verdict-status i { display: inline-block; width: 0.45rem; height: 0.45rem; margin-right: 0.3rem; border-radius: 50%; background: var(--amber); }
+.verdict-card__statement { margin: 2.2rem 0 2rem; font-size: clamp(1.5rem, 2.5vw, 2.35rem); font-weight: 650; letter-spacing: -0.04em; line-height: 1.13; }
+.verdict-card__statement span { color: var(--muted); }
+.verdict-scale { display: grid; grid-template-columns: repeat(3, 1fr); gap: 3px; margin-bottom: 1.5rem; color: #686762; font-family: var(--mono); font-size: 0.57rem; }
+.verdict-scale span { position: relative; padding-top: 0.65rem; border-top: 3px solid #242421; }
+.verdict-scale__active { color: var(--ink-soft) !important; border-color: var(--amber) !important; }
+.verdict-card__note { margin: 0; color: var(--ink-soft); font-size: 0.86rem; line-height: 1.55; }
+.hero-question-row { position: relative; display: grid; grid-template-columns: repeat(4, 1fr); margin-top: clamp(4rem, 8vw, 8rem); border-top: 1px solid var(--line); border-bottom: 1px solid var(--line); }
+.hero-question-row span { padding: 1rem 1.25rem; border-right: 1px solid var(--line); color: var(--muted); font-family: var(--mono); font-size: 0.66rem; text-transform: uppercase; }
+.hero-question-row span:first-child { padding-left: 0; }
+.hero-question-row span:last-child { border-right: 0; }
+
+.story-layout { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: clamp(3rem, 7vw, 7rem); align-items: start; }
+.story-index { position: sticky; top: 8rem; padding: 5.5rem 0; }
+.story-index__title { margin: 0 0 1.4rem; color: var(--ink-soft); font-family: var(--mono); font-size: 0.68rem; text-transform: uppercase; }
+.story-index ol { margin: 0; padding: 0; list-style: none; }
+.story-index li { border-top: 1px solid var(--line); }
+.story-index li:last-child { border-bottom: 1px solid var(--line); }
+.story-index a { display: flex; gap: 0.8rem; padding: 0.75rem 0; color: var(--muted); font-size: 0.8rem; text-decoration: none; transition: color .2s, transform .2s; }
+.story-index a:hover, .story-index a:focus-visible { color: var(--ink); transform: translateX(3px); }
+.story-index a span { color: #595852; font-family: var(--mono); }
+.legend-mini { margin-top: 2rem; }
+.legend-mini p { display: flex; align-items: center; gap: 0.55rem; margin: 0.45rem 0; color: var(--muted); font-family: var(--mono); font-size: 0.62rem; }
+.key { display: inline-block; width: 0.55rem; height: 0.55rem; border-radius: 2px; background: var(--muted); }
+.key--observed { background: var(--cyan); }.key--exposure { background: var(--amber); }.key--experiment { background: var(--violet); }.key--forecast { background: var(--green); }.key--high { background: var(--coral); }.key--muted { background: #292925; }
+
+.story-content { min-width: 0; }
+.story-section { padding: clamp(5rem, 10vw, 9rem) 0; border-bottom: 1px solid var(--line); scroll-margin-top: 6.5rem; }
+.section-heading { display: grid; grid-template-columns: 1fr auto; gap: 2rem; align-items: start; }
+.section-heading h2 { max-width: 950px; margin: 0; font-size: clamp(2.35rem, 5vw, 5rem); font-weight: 650; letter-spacing: -0.055em; line-height: 1.02; }
+.section-heading--compact h2 { font-size: clamp(2.15rem, 4vw, 3.8rem); }
+.chapter-number { color: #292925; font-family: var(--mono); font-size: clamp(3.5rem, 8vw, 7.5rem); font-weight: 500; letter-spacing: -0.08em; line-height: 0.75; }
+.section-intro { max-width: 810px; margin: 2rem 0 3.5rem; color: var(--ink-soft); font-size: clamp(1.02rem, 1.5vw, 1.23rem); line-height: 1.7; }
+
+.metric-strip { display: grid; grid-template-columns: repeat(3, 1fr); border: 1px solid var(--line); border-radius: 1.2rem 1.2rem 0 0; background: rgba(255,255,255,0.018); }
+.metric-strip article { padding: 1.35rem 1.5rem; border-right: 1px solid var(--line); }
+.metric-strip article:last-child { border-right: 0; }
+.metric-label { display: block; color: var(--muted); font-family: var(--mono); font-size: 0.65rem; text-transform: uppercase; }
+.metric-strip strong { display: block; margin: 0.25rem 0; color: var(--cyan); font-size: clamp(1.9rem, 4vw, 3.6rem); letter-spacing: -0.06em; line-height: 1.1; }
+.metric-strip small { color: var(--muted); font-size: 0.7rem; }
+
+.chart-card { border: 1px solid var(--line); border-radius: 1.2rem; background: var(--panel); }
+.chart-card--wide { padding: clamp(1rem, 2.5vw, 2rem); border-top: 0; border-radius: 0 0 1.2rem 1.2rem; }
+.chart-card__header { display: flex; justify-content: space-between; gap: 1.5rem; align-items: start; }
+.chart-card h3, .source-ledger h3, .watchlist-card h3 { margin: 0; font-size: 1.35rem; letter-spacing: -0.025em; }
+.chart-kicker { margin: 0 0 0.35rem; color: var(--muted); font-family: var(--mono); font-size: 0.64rem; letter-spacing: 0.08em; text-transform: uppercase; }
+.chart-switcher { display: flex; flex-wrap: wrap; gap: 0.35rem; padding: 0.25rem; border: 1px solid var(--line); border-radius: 999px; }
+.chart-switcher button { padding: 0.48rem 0.75rem; border: 0; border-radius: 999px; background: transparent; color: var(--muted); cursor: pointer; font-family: var(--mono); font-size: 0.65rem; }
+.chart-switcher button[aria-pressed="true"] { background: var(--cyan); color: #00151b; }
+.chart-switcher button:focus-visible { outline: 2px solid var(--ink); outline-offset: 2px; }
+.line-chart-wrap { position: relative; margin-top: 1.25rem; }
+.line-chart { display: block; width: 100%; height: auto; overflow: visible; touch-action: pan-y; }
+.chart-grid-line { stroke: var(--line); stroke-width: 1; }
+.chart-axis-label { fill: var(--muted); font-family: var(--mono); font-size: 11px; }
+.chart-year-label { fill: var(--ink-soft); }
+.chart-annotation-line { stroke: var(--amber); stroke-width: 1; stroke-dasharray: 5 5; opacity: .7; }
+.chart-annotation-label { fill: var(--amber); font-family: var(--mono); font-size: 10px; text-transform: uppercase; }
+.chart-area { fill: url(#market-area-gradient); }
+.chart-line { fill: none; stroke: var(--cyan); stroke-width: 3; stroke-linejoin: round; stroke-linecap: round; filter: drop-shadow(0 0 7px rgba(87,215,255,.22)); }
+.chart-latest-halo { fill: rgba(87,215,255,.15); stroke: rgba(87,215,255,.35); }
+.chart-latest-dot, .chart-focus-dot { fill: var(--cyan); stroke: var(--coal); stroke-width: 2; }
+.chart-focus-line { stroke: rgba(255,255,255,.3); stroke-width: 1; stroke-dasharray: 2 4; }
+.line-chart:focus-visible { outline: 2px solid var(--cyan); outline-offset: 4px; }
+.chart-tooltip { position: absolute; top: 0; left: 0; min-width: 98px; padding: .55rem .7rem; border: 1px solid var(--line-strong); border-radius: .55rem; background: rgba(5,5,5,.92); pointer-events: none; box-shadow: 0 12px 30px rgba(0,0,0,.45); }
+.chart-tooltip strong, .chart-tooltip span { display: block; }
+.chart-tooltip strong { color: var(--cyan); font-size: .9rem; }
+.chart-tooltip span { color: var(--muted); font-family: var(--mono); font-size: .59rem; }
+.chart-description { margin: 0.3rem 0 1rem; color: var(--muted); font-size: 0.78rem; }
+.chart-footer { display: flex; justify-content: space-between; gap: 1rem; padding-top: 1rem; border-top: 1px solid var(--line); color: var(--muted); font-family: var(--mono); font-size: 0.61rem; }
+.chart-footer a { color: var(--ink-soft); text-underline-offset: 3px; }
+.annotation-line { display: inline-block; width: 1.5rem; margin-right: .4rem; border-top: 1px dashed var(--amber); vertical-align: middle; }
+.data-table-wrap { margin-top: 1rem; color: var(--muted); font-size: .72rem; }
+.data-table-wrap summary { width: fit-content; cursor: pointer; font-family: var(--mono); text-decoration: underline; text-underline-offset: 3px; }
+.data-table-scroll { max-height: 18rem; overflow: auto; margin-top: .8rem; border: 1px solid var(--line); border-radius: .7rem; }
+.data-table-scroll table { width: 100%; border-collapse: collapse; }
+.data-table-scroll caption { padding: .7rem; text-align: left; color: var(--ink-soft); }
+.data-table-scroll th, .data-table-scroll td { padding: .55rem .75rem; border-top: 1px solid var(--line); text-align: left; }
+.data-table-scroll td { color: var(--ink-soft); }
+.reading-note { display: grid; grid-template-columns: auto 1fr 1fr; gap: 1.4rem; margin-top: 1.25rem; padding: 1.3rem; border: 1px solid rgba(87,215,255,.22); border-radius: 1rem; background: rgba(87,215,255,.045); }
+.reading-note__mark { display: grid; width: 2rem; height: 2rem; place-items: center; border-radius: 50%; background: var(--cyan); color: #00151b; font-family: var(--mono); font-weight: 700; }
+.reading-note strong { font-size: .8rem; }
+.reading-note p { margin: .25rem 0 0; color: var(--muted); font-size: .76rem; }
+
+.exposure-card { padding: clamp(1.4rem, 3vw, 2.2rem); border: 1px solid rgba(247,181,0,.25); border-radius: 1.25rem; background: linear-gradient(140deg, rgba(247,181,0,.065), rgba(255,255,255,.015)); }
+.exposure-card__headline { display: grid; grid-template-columns: 1fr 1fr; gap: 1.5rem; }
+.exposure-card__headline > div:last-child { padding-left: 1.5rem; border-left: 1px solid var(--line); }
+.exposure-card__headline span { display: block; color: var(--muted); font-family: var(--mono); font-size: .66rem; text-transform: uppercase; }
+.exposure-card__headline strong { display: block; margin-top: .25rem; font-size: clamp(2.6rem, 7vw, 6rem); letter-spacing: -.08em; line-height: 1; }
+.exposure-card__headline div:first-child strong { color: var(--amber); }
+.exposure-card__headline div:last-child strong { color: var(--coral); }
+.exposure-chart { display: flex; height: clamp(2rem, 5vw, 4rem); margin: 2.2rem 0 1rem; overflow: hidden; border-radius: .5rem; background: #24241f; }
+.exposure-chart span { display: block; min-width: 2px; border-right: 2px solid var(--panel); }
+.exposure-chart__high { background: var(--coral); }.exposure-chart__some { background: var(--amber); }.exposure-chart__lower { background: #292925; }
+.exposure-legend { display: flex; flex-wrap: wrap; gap: .7rem 1.4rem; color: var(--muted); font-family: var(--mono); font-size: .61rem; }
+.exposure-legend span { display: flex; align-items: center; gap: .45rem; }
+.two-column-notes { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-top: 1rem; }
+.fact-card { position: relative; min-height: 18rem; padding: 1.8rem; overflow: hidden; border: 1px solid var(--line); border-radius: 1rem; background: var(--panel); }
+.fact-card__index { position: absolute; right: 1rem; top: .5rem; color: #252522; font-family: var(--mono); font-size: 5rem; font-weight: 500; line-height: 1; }
+.fact-card__label { margin: 0 0 1rem; color: var(--muted) !important; font-family: var(--mono); font-size: .62rem !important; text-transform: uppercase; }
+.fact-card h3 { position: relative; max-width: 27rem; margin: 0 0 1rem; font-size: 1.45rem; letter-spacing: -.035em; line-height: 1.25; }
+.fact-card p { position: relative; color: var(--muted); font-size: .85rem; }
+.mini-comparison { position: relative; margin: 1.3rem 0; }
+.mini-comparison div { display: grid; grid-template-columns: 3.5rem 1fr 2.8rem; align-items: center; gap: .7rem; margin: .65rem 0; color: var(--muted); font-family: var(--mono); font-size: .65rem; }
+.mini-comparison i { height: .65rem; border-radius: 999px; background: linear-gradient(90deg, var(--coral) calc(var(--value) / 6 * 100%), #242421 0); }
+.mini-comparison b { color: var(--ink); }
+
+.contrast-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.contrast-card { display: flex; min-height: 31rem; flex-direction: column; padding: clamp(1.5rem, 3vw, 2.25rem); border: 1px solid var(--line); border-radius: 1.25rem; }
+.contrast-card--warning { border-color: rgba(255,107,95,.28); background: linear-gradient(145deg, rgba(255,107,95,.07), rgba(255,255,255,.015)); }
+.contrast-card--calm { border-color: rgba(87,215,255,.22); background: linear-gradient(145deg, rgba(87,215,255,.055), rgba(255,255,255,.015)); }
+.contrast-card__type { color: var(--muted); font-family: var(--mono); font-size: .63rem; text-transform: uppercase; }
+.contrast-card__number { margin: 1.8rem 0 .5rem; color: var(--coral); font-size: clamp(4rem, 8vw, 7rem); letter-spacing: -.09em; line-height: 1; }
+.contrast-card h3 { margin: 1rem 0; font-size: clamp(1.3rem, 2.3vw, 1.9rem); letter-spacing: -.04em; line-height: 1.25; }
+.contrast-card > p { color: var(--muted); font-size: .88rem; }
+.contrast-card footer { display: flex; flex-wrap: wrap; justify-content: space-between; gap: .5rem; margin-top: auto; padding-top: 1.4rem; border-top: 1px solid var(--line); color: var(--muted); font-family: var(--mono); font-size: .57rem; }
+.contrast-card footer a { color: var(--ink-soft); }
+.no-break-graphic { display: flex; align-items: end; gap: .45rem; height: 7rem; margin: 2.5rem 0 .8rem; }
+.no-break-graphic span { flex: 1; height: 45%; border-top: 2px solid var(--cyan); background: linear-gradient(to bottom, rgba(87,215,255,.13), transparent); }
+.no-break-graphic span:nth-child(2) { height: 53%; }.no-break-graphic span:nth-child(3) { height: 48%; }.no-break-graphic span:nth-child(4) { height: 58%; }.no-break-graphic span:nth-child(5) { height: 52%; }
+.interpretation-panel { display: grid; grid-template-columns: 9rem 1fr; gap: 2rem; margin: 1rem 0; padding: 1.6rem 1.8rem; border: 1px solid var(--line); border-radius: 1rem; background: #f1ede2; color: #171714; }
+.interpretation-panel__label { margin: .2rem 0 0; font-family: var(--mono); font-size: .64rem; text-transform: uppercase; }
+.interpretation-panel > p:last-child { margin: 0; font-size: 1.05rem; line-height: 1.65; }
+.watchlist-card { display: grid; grid-template-columns: minmax(180px, .55fr) 1fr; gap: 2rem; padding: 1.6rem; border: 1px solid var(--line); border-radius: 1rem; background: var(--panel); }
+.watchlist-card ol { margin: 0; padding: 0; list-style: none; }
+.watchlist-card li { display: grid; grid-template-columns: 2.25rem 1fr; gap: .8rem; padding: .8rem 0; border-top: 1px solid var(--line); }
+.watchlist-card li:first-child { border-top: 0; padding-top: 0; }
+.watchlist-card li > span { color: var(--muted); font-family: var(--mono); font-size: .62rem; }
+.watchlist-card li p { margin: 0; color: var(--muted); font-size: .76rem; }
+.watchlist-card li strong { display: block; color: var(--ink); font-size: .82rem; }
+
+.forecast-card { padding: clamp(1.5rem, 3vw, 2.3rem); }
+.forecast-summary { display: grid; grid-template-columns: repeat(3, 1fr); margin-bottom: 2.5rem; border-bottom: 1px solid var(--line); }
+.forecast-summary > div { padding: 0 1.5rem 1.5rem; border-right: 1px solid var(--line); }
+.forecast-summary > div:first-child { padding-left: 0; }.forecast-summary > div:last-child { border-right: 0; }
+.forecast-summary span { display: block; color: var(--muted); font-family: var(--mono); font-size: .62rem; text-transform: uppercase; }
+.forecast-summary strong { display: block; margin-top: .2rem; font-size: clamp(2rem, 5vw, 4.5rem); letter-spacing: -.07em; line-height: 1.1; }
+.forecast-summary > div:first-child strong { color: var(--green); }.forecast-summary > div:nth-child(2) strong { color: var(--coral); }.forecast-summary__net strong { color: var(--ink); }
+.bar-row { display: grid; grid-template-columns: 6rem 1fr 4.5rem; align-items: center; gap: 1rem; margin: 1rem 0; }
+.bar-row > span { color: var(--muted); font-family: var(--mono); font-size: .66rem; }
+.bar-row > div { height: 2rem; overflow: hidden; border-radius: .3rem; background: #22221e; }
+.bar-row i { display: block; height: 100%; border-radius: inherit; transform-origin: left; animation: grow-bar .8s cubic-bezier(.2,.8,.2,1) both; }
+.bar-row strong { font-family: var(--mono); font-size: .75rem; text-align: right; }
+.bar-row--created i { background: var(--green); }.bar-row--displaced i { background: var(--coral); }.bar-row--net i { background: var(--ink-soft); }
+.forecast-scope { margin: 2rem 0 0; padding-top: 1.2rem; border-top: 1px solid var(--line); color: var(--muted); font-size: .76rem; }
+.forecast-scope strong { color: var(--ink); }
+.forecast-caveat { display: grid; grid-template-columns: auto 1fr; align-items: center; gap: 1.3rem; margin-top: 1rem; padding: 1.2rem 1.5rem; border: 1px solid rgba(83,211,139,.22); border-radius: 1rem; background: rgba(83,211,139,.04); }
+.forecast-caveat > span { color: var(--green); font-size: 2.6rem; font-weight: 700; letter-spacing: -.06em; }
+.forecast-caveat p { margin: 0; color: var(--muted); font-size: .8rem; }
+.forecast-caveat strong { color: var(--ink); }
+
+.work-grid { display: grid; grid-template-columns: 1.25fr .75fr; gap: 1rem; }
+.productivity-card { padding: 1.7rem; }
+.sample-badge { padding: .4rem .7rem; border: 1px solid rgba(165,139,255,.3); border-radius: 999px; color: var(--violet); font-family: var(--mono); font-size: .62rem; }
+.productivity-chart { margin: 2.7rem 0; }
+.productivity-row { margin: 1.5rem 0; }
+.productivity-row > div:first-child { display: flex; justify-content: space-between; margin-bottom: .55rem; color: var(--muted); font-size: .75rem; }
+.productivity-row strong { color: var(--violet); font-family: var(--mono); }
+.productivity-track { height: 2.7rem; overflow: hidden; border-radius: .35rem; background: #242420; }
+.productivity-track i { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #745df0, var(--violet)); animation: grow-bar .8s cubic-bezier(.2,.8,.2,1) both; }
+.adoption-card { position: relative; min-height: 28rem; overflow: hidden; padding: 1.7rem; border: 1px solid rgba(247,181,0,.25); border-radius: 1.2rem; background: linear-gradient(145deg, rgba(247,181,0,.075), var(--panel)); }
+.adoption-card > strong { display: block; margin: 1.5rem 0 .3rem; color: var(--amber); font-size: clamp(4rem, 8vw, 7rem); letter-spacing: -.09em; line-height: 1; }
+.adoption-card h3 { max-width: 22rem; margin: 0; font-size: 1.45rem; letter-spacing: -.04em; line-height: 1.25; }
+.adoption-card > p:last-child { position: absolute; z-index: 1; right: 1.7rem; bottom: 1.7rem; left: 1.7rem; margin: 0; color: var(--muted); font-size: .8rem; }
+.adoption-ring { position: absolute; right: -18%; bottom: -18%; width: 70%; aspect-ratio: 1; border: 1px solid rgba(247,181,0,.18); border-radius: 50%; box-shadow: 0 0 0 2rem rgba(247,181,0,.018), 0 0 0 4rem rgba(247,181,0,.012); }
+.adoption-ring span { position: absolute; inset: 24%; border: 1px dashed rgba(247,181,0,.22); border-radius: 50%; }
+
+.answer-section { border-bottom: 0; }
+.answer-card { margin-top: 3rem; overflow: hidden; border: 1px solid rgba(247,181,0,.3); border-radius: 1.4rem; background: linear-gradient(135deg, rgba(247,181,0,.07), rgba(255,255,255,.018)); }
+.answer-card__lead { margin: 0; padding: 2rem; border-bottom: 1px solid var(--line); font-size: clamp(1.45rem, 3vw, 2.4rem); font-weight: 650; letter-spacing: -.045em; }
+.answer-grid { display: grid; grid-template-columns: repeat(3, 1fr); }
+.answer-grid article { padding: 1.7rem; border-right: 1px solid var(--line); }
+.answer-grid article:last-child { border-right: 0; }
+.answer-icon { display: grid; width: 2.2rem; height: 2.2rem; place-items: center; border-radius: 50%; font-family: var(--mono); font-weight: 700; }
+.answer-icon--yes { background: var(--green); color: #022011; }.answer-icon--no { background: var(--coral); color: #290200; }.answer-icon--watch { background: var(--amber); color: #231800; }
+.answer-grid h3 { margin: 1rem 0 .8rem; font-size: 1.05rem; }
+.answer-grid ul { margin: 0; padding: 0; list-style: none; }
+.answer-grid li { position: relative; margin: .75rem 0; padding-left: 1rem; color: var(--muted); font-size: .77rem; }
+.answer-grid li::before { content: '·'; position: absolute; left: 0; color: var(--ink-soft); }
+
+.methodology-section { padding-top: 2rem; }
+.method-grid { display: grid; grid-template-columns: repeat(4, 1fr); margin-top: 3rem; border: 1px solid var(--line); border-radius: 1rem; }
+.method-grid article { min-height: 14rem; padding: 1.4rem; border-right: 1px solid var(--line); }
+.method-grid article:last-child { border-right: 0; }
+.method-grid span { color: var(--amber); font-family: var(--mono); font-size: .65rem; }
+.method-grid h3 { margin: 2.5rem 0 .65rem; font-size: .9rem; }
+.method-grid p { margin: 0; color: var(--muted); font-size: .73rem; }
+.source-ledger { margin-top: 1rem; overflow: hidden; border: 1px solid var(--line); border-radius: 1rem; background: var(--panel); }
+.source-ledger__header { display: flex; justify-content: space-between; align-items: end; gap: 1rem; padding: 1.5rem; border-bottom: 1px solid var(--line); }
+.source-ledger__header > span { color: var(--muted); font-family: var(--mono); font-size: .63rem; }
+.sources-list { margin: 0; padding: 0; list-style: none; }
+.sources-list li { display: grid; grid-template-columns: 2.5rem 1fr; gap: 1rem; padding: 1.25rem 1.5rem; border-bottom: 1px solid var(--line); }
+.sources-list li:last-child { border-bottom: 0; }
+.source-number { color: #5d5b55; font-family: var(--mono); font-size: .65rem; }
+.sources-list a { font-size: .87rem; font-weight: 600; text-decoration-color: #54534d; text-underline-offset: 4px; }
+.sources-list a:hover { color: var(--amber); }
+.source-meta, .source-note { margin: .35rem 0 0; }
+.source-meta { color: var(--ink-soft); font-family: var(--mono); font-size: .61rem; }
+.source-note { color: var(--muted); font-size: .72rem; }
+
+.future-section { position: relative; display: grid; grid-template-columns: 1fr .8fr; gap: 3rem; margin: 2rem 0 clamp(5rem,10vw,9rem); padding: clamp(2rem,5vw,4rem); overflow: hidden; border: 1px solid rgba(165,139,255,.24); border-radius: 1.4rem; background: linear-gradient(135deg, rgba(165,139,255,.075), rgba(255,255,255,.015)); }
+.future-section h2 { max-width: 650px; margin: 0; font-size: clamp(2rem,4vw,4rem); letter-spacing: -.055em; line-height: 1.05; }
+.future-section > div:first-child > p:last-child { max-width: 640px; color: var(--muted); font-size: .9rem; }
+.future-metrics { display: grid; grid-template-columns: 1fr 1fr; align-content: center; gap: .6rem; }
+.future-metrics span { padding: .8rem; border: 1px solid var(--line); border-radius: .65rem; color: var(--ink-soft); font-family: var(--mono); font-size: .64rem; text-align: center; }
+.future-badge { position: absolute; right: 1rem; top: 1rem; color: var(--violet); font-family: var(--mono); font-size: .6rem; text-decoration: none; text-transform: uppercase; }
+.signal-footer { border-top: 1px solid var(--line); }
+.signal-footer__inner { display: flex; justify-content: space-between; gap: 2rem; padding-block: 2.5rem; color: var(--muted); font-size: .75rem; }
+.signal-footer__inner p { margin: 0; }.signal-footer strong { color: var(--ink); }
+.signal-footer__inner > div { display: flex; gap: 1.2rem; }.signal-footer a { text-underline-offset: 3px; }
+.noscript-note, .chart-error { margin: 1rem; padding: 1rem; border: 1px solid var(--coral); border-radius: .7rem; background: rgba(255,107,95,.08); color: var(--ink-soft); }
+
+.has-motion .reveal { opacity: 0; transform: translateY(28px); transition: opacity .65s ease, transform .65s ease; }
+.has-motion .reveal.is-visible { opacity: 1; transform: none; }
+@keyframes grow-bar { from { transform: scaleX(0); } to { transform: scaleX(1); } }
+
+@media (max-width: 1100px) {
+  .hero-grid { grid-template-columns: 1fr; }
+  .verdict-card { max-width: 650px; }
+  .story-layout { grid-template-columns: 1fr; }
+  .story-index { position: static; display: none; }
+  .story-content { max-width: 100%; }
+  .method-grid { grid-template-columns: 1fr 1fr; }
+  .method-grid article:nth-child(2) { border-right: 0; }
+  .method-grid article:nth-child(-n+2) { border-bottom: 1px solid var(--line); }
+}
+
+@media (max-width: 760px) {
+  .signal-shell { width: min(100% - 2rem, 1480px); }
+  .signal-hero { padding-top: 7.2rem; }
+  .topic-switcher { align-items: flex-start; flex-wrap: wrap; margin-bottom: 3.5rem; }
+  .topic-switcher__label { width: 100%; margin-bottom: .2rem; }
+  .topic-pill--future { display: none; }
+  .hero-copy h1 { font-size: clamp(3rem, 15vw, 5.5rem); }
+  .hero-question-row { grid-template-columns: 1fr 1fr; }
+  .hero-question-row span { padding-left: .7rem; border-bottom: 1px solid var(--line); }
+  .hero-question-row span:nth-child(2) { border-right: 0; }
+  .hero-question-row span:nth-child(n+3) { border-bottom: 0; }
+  .chapter-number { display: none; }
+  .metric-strip, .exposure-card__headline, .contrast-grid, .work-grid, .answer-grid, .future-section { grid-template-columns: 1fr; }
+  .metric-strip article { border-right: 0; border-bottom: 1px solid var(--line); }
+  .metric-strip article:last-child { border-bottom: 0; }
+  .chart-card__header { align-items: stretch; flex-direction: column; }
+  .chart-switcher { width: 100%; }
+  .chart-switcher button { flex: 1; padding-inline: .4rem; }
+  .line-chart { min-width: 650px; }
+  .line-chart-wrap { overflow-x: auto; padding-bottom: .5rem; }
+  .chart-tooltip { display: none; }
+  .chart-footer { align-items: flex-start; flex-direction: column; }
+  .reading-note { grid-template-columns: auto 1fr; }
+  .reading-note > div:last-child { grid-column: 2; }
+  .exposure-card__headline > div:last-child { padding: 1.2rem 0 0; border-top: 1px solid var(--line); border-left: 0; }
+  .two-column-notes { grid-template-columns: 1fr; }
+  .contrast-card { min-height: 28rem; }
+  .interpretation-panel, .watchlist-card { grid-template-columns: 1fr; gap: .8rem; }
+  .forecast-summary { grid-template-columns: 1fr; }
+  .forecast-summary > div { padding: 1rem 0; border-right: 0; border-bottom: 1px solid var(--line); }
+  .forecast-summary > div:last-child { border-bottom: 0; }
+  .bar-row { grid-template-columns: 4.7rem 1fr 3.7rem; gap: .6rem; }
+  .answer-grid article { border-right: 0; border-bottom: 1px solid var(--line); }
+  .answer-grid article:last-child { border-bottom: 0; }
+  .future-section { gap: 1.5rem; }
+  .future-metrics { margin-top: 1rem; }
+  .signal-footer__inner { align-items: flex-start; flex-direction: column; }
+}
+
+@media (max-width: 500px) {
+  .hero-copy h1 { letter-spacing: -.065em; }
+  .hero-deck { font-size: 1rem; }
+  .verdict-card { padding: 1.25rem; }
+  .verdict-card__topline { align-items: flex-start; flex-direction: column; gap: .3rem; }
+  .verdict-scale { font-size: .49rem; }
+  .section-heading h2 { font-size: clamp(2.25rem, 12vw, 3.4rem); }
+  .story-section { padding: 5rem 0; }
+  .reading-note { grid-template-columns: 1fr; }
+  .reading-note > div:last-child { grid-column: auto; }
+  .fact-card { min-height: 0; }
+  .contrast-card footer { flex-direction: column; }
+  .forecast-caveat { grid-template-columns: 1fr; }
+  .method-grid { grid-template-columns: 1fr; }
+  .method-grid article { min-height: 0; border-right: 0; border-bottom: 1px solid var(--line); }
+  .method-grid article:nth-child(3) { border-bottom: 1px solid var(--line); }
+  .method-grid article:last-child { border-bottom: 0; }
+  .method-grid h3 { margin-top: 1.3rem; }
+  .source-ledger__header { align-items: flex-start; flex-direction: column; }
+  .sources-list li { grid-template-columns: 1fr; gap: .4rem; padding-inline: 1rem; }
+  .future-metrics { grid-template-columns: 1fr; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto !important; }
+  *, *::before, *::after { animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+}

--- a/ctw.studio/signals/tests/dashboard.test.mjs
+++ b/ctw.studio/signals/tests/dashboard.test.mjs
@@ -1,0 +1,117 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const data = JSON.parse(await readFile(new URL('data/ai-jobs.json', root), 'utf8'));
+const html = await readFile(new URL('index.html', root), 'utf8');
+const script = await readFile(new URL('dashboard.js', root), 'utf8');
+
+const requiredSeries = ['openings', 'hires', 'unemployment'];
+const requiredEvidence = ['iloExposure', 'earlyCareer', 'macroLabour', 'wefForecast', 'productivity', 'adoption'];
+
+function isSorted(observations) {
+  return observations.every((item, index) => index === 0 || observations[index - 1].date < item.date);
+}
+
+function monthlyDates(start, end) {
+  const result = [];
+  const cursor = new Date(`${start}T00:00:00Z`);
+  const final = new Date(`${end}T00:00:00Z`);
+  while (cursor <= final) {
+    result.push(cursor.toISOString().slice(0, 10));
+    cursor.setUTCMonth(cursor.getUTCMonth() + 1);
+  }
+  return result;
+}
+
+test('official series are populated, sorted, and current through 2026', () => {
+  for (const key of requiredSeries) {
+    const series = data.series[key];
+    assert.ok(series, `missing ${key}`);
+    assert.ok(series.observations.length >= 70, `${key} should contain monthly history from 2020`);
+    assert.ok(isSorted(series.observations), `${key} observations must be strictly chronological`);
+    assert.deepEqual(series.latest, series.observations.at(-1), `${key} latest must match the final observation`);
+    assert.match(series.fredId, /^[A-Z]+$/);
+    assert.ok(series.observations.at(-1).date >= '2026-05-01', `${key} is unexpectedly stale`);
+  }
+});
+
+test('headline values are derived from published observations', () => {
+  const openings = data.series.openings.observations;
+  const unemployment = data.series.unemployment.observations;
+  const baseline = data.headline.chatgptBaseline;
+  const openingsBaseline = openings.find((item) => item.date === baseline);
+  const unemploymentBaseline = unemployment.find((item) => item.date === baseline);
+
+  assert.deepEqual(data.headline.openingsAtBaseline, openingsBaseline);
+  assert.deepEqual(data.headline.openingsLatest, openings.at(-1));
+  assert.deepEqual(data.headline.unemploymentAtBaseline, unemploymentBaseline);
+  assert.deepEqual(data.headline.unemploymentLatest, unemployment.at(-1));
+
+  const expectedOpeningsChange = Number((((openings.at(-1).value - openingsBaseline.value) / openingsBaseline.value) * 100).toFixed(1));
+  const expectedUnemploymentChange = Number((unemployment.at(-1).value - unemploymentBaseline.value).toFixed(1));
+  assert.equal(data.headline.openingsChangeSinceBaselinePct, expectedOpeningsChange);
+  assert.equal(data.headline.unemploymentChangeSinceBaselinePoints, expectedUnemploymentChange);
+});
+
+test('monthly series gaps are explicit and limited to documented unavailable data', () => {
+  for (const key of requiredSeries) {
+    const series = data.series[key];
+    const dates = new Set(series.observations.map((item) => item.date));
+    const expected = monthlyDates(series.observations[0].date, series.observations.at(-1).date);
+    const missing = expected.filter((date) => !dates.has(date));
+    assert.deepEqual(missing, (series.unavailable || []).map((item) => item.date), `${key} has an undocumented gap`);
+  }
+  assert.deepEqual(data.series.unemployment.unavailable, [{
+    date: '2025-10-01',
+    reason: 'Data unavailable due to the 2025 lapse in appropriations.'
+  }]);
+});
+
+test('curated evidence has a valid source, scope, period, and evidence type', () => {
+  const sourceIds = new Set(data.sources.map((source) => source.id));
+  for (const key of requiredEvidence) {
+    const evidence = data.evidence[key];
+    assert.ok(evidence, `missing ${key}`);
+    assert.ok(evidence.scope || key === 'adoption', `${key} needs a scope`);
+    assert.ok(evidence.period, `${key} needs a period`);
+    assert.ok(evidence.kind, `${key} needs an evidence kind`);
+    assert.ok(evidence.interpretation, `${key} needs an interpretation`);
+    assert.ok(sourceIds.has(evidence.sourceId), `${key} references a missing source`);
+  }
+});
+
+test('source ledger is auditable and uses secure links', () => {
+  assert.ok(data.sources.length >= 8);
+  const ids = new Set();
+  for (const source of data.sources) {
+    assert.ok(!ids.has(source.id), `duplicate source id ${source.id}`);
+    ids.add(source.id);
+    assert.match(source.url, /^https:\/\//);
+    assert.ok(source.institution && source.title && source.date && source.note);
+  }
+});
+
+test('page exposes the story, active navigation, chart alternatives, and method', () => {
+  assert.match(html, /data-active="signals"/);
+  assert.match(html, /id="big-picture"/);
+  assert.match(html, /id="exposure"/);
+  assert.match(html, /id="uneven"/);
+  assert.match(html, /id="expectations"/);
+  assert.match(html, /id="answer"/);
+  assert.match(html, /id="market-data-table"/);
+  assert.match(html, /market-chart-keyboard-help/);
+  assert.match(html, /id="market-chart"[^>]*tabindex="0"/);
+  assert.match(html, /id="sources-list"/);
+  assert.match(html, /Housing &amp; affordability/);
+});
+
+test('dashboard renders from the published data file without third-party chart code', () => {
+  assert.match(script, /data\/ai-jobs\.json/);
+  assert.match(script, /renderMarketChart/);
+  assert.match(script, /renderDataTable/);
+  assert.match(script, /safeHttpsUrl/);
+  assert.match(script, /ArrowLeft/);
+  assert.doesNotMatch(script, /chart\.js|d3\.js|plotly/i);
+});

--- a/ctw.studio/signals/tests/food.test.mjs
+++ b/ctw.studio/signals/tests/food.test.mjs
@@ -1,0 +1,109 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const data = JSON.parse(await readFile(new URL('data/food-system.json', root), 'utf8'));
+const html = await readFile(new URL('food/index.html', root), 'utf8');
+const script = await readFile(new URL('food/food.js', root), 'utf8');
+const nav = await readFile(new URL('../nav.js', root), 'utf8');
+
+function isLeap(year) {
+  return year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+}
+
+test('tracked land-animal totals reconcile to the species observations', () => {
+  assert.ok(data.slaughter.year >= 2024);
+  assert.equal(data.slaughter.daysInYear, isLeap(data.slaughter.year) ? 366 : 365);
+  assert.equal(data.slaughter.species.length, 7);
+
+  const annual = data.slaughter.species.reduce((sum, item) => sum + item.annual, 0);
+  assert.equal(data.slaughter.annualTracked, annual);
+  assert.equal(data.slaughter.dailyTracked, Math.round(annual / data.slaughter.daysInYear));
+  assert.equal(data.slaughter.perMinuteTracked, Math.round(annual / data.slaughter.daysInYear / 24 / 60));
+  assert.ok(data.slaughter.species.every((item) => item.annual > 0 && item.daily > 0));
+  assert.match(data.slaughter.note, /excludes fish/i);
+});
+
+test('fish estimates retain ranges, method warnings, and separate units', () => {
+  const { farmed, wild } = data.fishCounts;
+  assert.ok(farmed.annualLowBillions < farmed.annualMidpointBillions);
+  assert.ok(farmed.annualMidpointBillions < farmed.annualHighBillions);
+  assert.ok(wild.annualLowBillions < wild.annualHighBillions);
+  assert.match(farmed.note, /not an official head count/i);
+  assert.match(wild.note, /uncertain/i);
+  assert.notEqual(farmed.sourceId, wild.sourceId);
+});
+
+test('product footprints are positive, ordered, and include animal and plant comparisons', () => {
+  assert.equal(data.productFootprints.length, 7);
+  const names = new Set(data.productFootprints.map((item) => item.product));
+  for (const required of ['Beef (beef herd)', 'Poultry Meat', 'Tofu', 'Peas']) {
+    assert.ok(names.has(required), `missing ${required}`);
+  }
+  assert.ok(data.productFootprints.every((item) => item.kgCO2ePerKgFood > 0));
+  assert.ok(data.productFootprints[0].kgCO2ePerKgFood > data.productFootprints.at(-1).kgCO2ePerKgFood);
+});
+
+test('every evidence reference resolves to a secure, unique source', () => {
+  assert.ok(data.sources.length >= 10);
+  const sourceIds = new Set();
+  for (const source of data.sources) {
+    assert.ok(!sourceIds.has(source.id), `duplicate source ${source.id}`);
+    sourceIds.add(source.id);
+    assert.match(source.url, /^https:\/\//);
+    for (const field of ['title', 'publisher', 'publicationDate', 'role', 'kind']) {
+      assert.ok(source[field], `${source.id} missing ${field}`);
+    }
+  }
+
+  const directRefs = [
+    data.slaughter.sourceId,
+    data.fishCounts.farmed.sourceId,
+    data.fishCounts.wild.sourceId,
+    data.climate.sourceId,
+    data.land.sourceId,
+    data.forests.sourceId,
+    data.oceans.sourceId,
+    data.health.sourceId,
+    data.health.guidanceSourceId,
+    ...data.water.sourceIds
+  ];
+  directRefs.forEach((id) => assert.ok(sourceIds.has(id), `missing referenced source ${id}`));
+});
+
+test('agriculture-wide numbers are explicitly not presented as livestock-only', () => {
+  assert.equal(data.water.agricultureFreshwaterWithdrawalPct, 69);
+  assert.equal(data.water.agricultureEutrophicationPct, 78);
+  assert.match(data.water.note, /agriculture-wide/i);
+  assert.match(data.water.note, /do not assign/i);
+  assert.match(html, /We cannot say:[\s\S]*livestock alone causes 69%/);
+});
+
+test('food page exposes the complete storyboard, chart alternatives, and active topic', () => {
+  assert.match(html, /data-active="signals"/);
+  for (const id of ['lives', 'climate', 'land', 'water', 'oceans', 'health', 'answer', 'sources']) {
+    assert.match(html, new RegExp(`id="${id}"`));
+  }
+  assert.match(html, /href="\.\.\/"[^>]*>AI &amp; work/);
+  assert.match(html, /food-active/);
+  assert.match(html, /species-table/);
+  assert.match(html, /footprint-table/);
+  assert.match(html, /Scenario, not forecast/);
+  assert.match(html, /relative risk/i);
+});
+
+test('food dashboard uses baked data without third-party chart libraries', () => {
+  assert.match(script, /data\/food-system\.json/);
+  assert.match(script, /renderSpecies/);
+  assert.match(script, /renderFootprints/);
+  assert.match(script, /renderSources/);
+  assert.match(script, /safeHttpsUrl/);
+  assert.doesNotMatch(script, /chart\.js|d3\.js|plotly/i);
+});
+
+test('site navigation exposes Signals', () => {
+  assert.match(nav, /id: 'signals'/);
+  assert.match(nav, /data-active/);
+  assert.match(nav, /aria-current="page"/);
+});

--- a/ctw.studio/signals/tests/housing.test.mjs
+++ b/ctw.studio/signals/tests/housing.test.mjs
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const data = JSON.parse(await readFile(new URL('data/housing.json', root), 'utf8'));
+const html = await readFile(new URL('housing/index.html', root), 'utf8');
+const script = await readFile(new URL('housing/housing.js', root), 'utf8');
+
+function isSorted(rows) {
+  return rows.every((row, index) => index === 0 || rows[index - 1].period < row.period);
+}
+
+test('housing implements the shared five-question and three-lens contract', () => {
+  assert.deepEqual(data.framework.questions.map((item) => item.id), [
+    'where-now',
+    'direction',
+    'distribution',
+    'explanations',
+    'change-evidence'
+  ]);
+  assert.deepEqual(data.framework.lenses.map((item) => item.id), ['world', 'netherlands-europe', 'comparisons']);
+  assert.ok(data.framework.possibilityQuestion);
+  assert.match(data.meta.question, /ordinary life/i);
+});
+
+test('OECD affordability series are chronological and expose the Netherlands baseline shift', () => {
+  for (const key of ['housePrice', 'rentPrice', 'priceToIncome', 'priceToRent']) {
+    const series = data.netherlands.oecd[key];
+    assert.ok(series.observations.length >= 40, `${key} needs quarterly history`);
+    assert.ok(isSorted(series.observations), `${key} must be chronological`);
+    assert.deepEqual(series.latest, series.observations.at(-1));
+    assert.equal(series.base, '2015=100');
+  }
+  assert.ok(data.netherlands.oecd.priceToIncome.latest.value > 130);
+  assert.ok(data.netherlands.oecd.housePrice.latest.value > data.netherlands.oecd.rentPrice.latest.value);
+});
+
+test('current Netherlands observations reconcile and preserve scope', () => {
+  assert.match(data.netherlands.cbs.existingHomes.latest.period, /^2026-/);
+  assert.ok(data.netherlands.cbs.existingHomes.latest.averagePurchasePriceEur > 400000);
+  assert.equal(data.netherlands.ecbMortgage.unit, '% per year');
+  assert.ok(data.netherlands.ecbMortgage.observations.length >= 100);
+
+  const marketRent = data.netherlands.overburden.byTenure.find((item) => item.tenure === 'Market-rate tenant');
+  const mortgagedOwner = data.netherlands.overburden.byTenure.find((item) => item.tenure === 'Owner with mortgage');
+  assert.ok(marketRent.value > mortgagedOwner.value);
+  assert.match(data.netherlands.overburden.definition, /40%/);
+
+  assert.equal(data.netherlands.supplyVsHouseholds.length, 7);
+  for (const row of data.netherlands.supplyVsHouseholds) {
+    assert.equal(row.householdGrowth, row.householdsEnd - row.householdsStart);
+  }
+});
+
+test('selected-country comparison is mechanism-led, harmonized, and not a ranking', () => {
+  assert.equal(data.comparisons.period, '2025-Q4');
+  assert.equal(data.comparisons.measure, 'Price-to-income index');
+  assert.equal(data.comparisons.countries.length, 6);
+  assert.ok(data.comparisons.countries.some((item) => item.code === 'NLD'));
+  assert.ok(data.comparisons.countries.every((item) => item.whyIncluded && item.value > 0));
+  assert.match(data.comparisons.caveat, /not an absolute affordability ranking/i);
+});
+
+test('world lens labels its derived estimate and exposes exact calculation inputs', () => {
+  assert.equal(data.world.slumShare.unit, '% of urban population');
+  assert.equal(data.world.slumShare.period, '2022');
+  assert.ok(data.world.slumShare.value > 20);
+  assert.ok(data.world.slumShare.rawValue > data.world.slumShare.value);
+  assert.ok(Number.isInteger(data.world.urbanPopulation.valuePeople));
+  const recomputedMillions = Math.round(
+    data.world.slumShare.rawValue / 100 * data.world.urbanPopulation.valuePeople / 1_000_000
+  );
+  assert.equal(data.world.estimatedPeople.valueMillions, recomputedMillions);
+  assert.equal(data.world.estimatedPeople.derived, true);
+  assert.match(data.world.estimatedPeople.note, /unrounded source values/i);
+  assert.match(data.world.limitations, /global affordability/i);
+});
+
+test('housing source ledger is unique, secure, and fully referenced', () => {
+  const ids = new Set();
+  for (const source of data.sources) {
+    assert.ok(!ids.has(source.id), `duplicate source ${source.id}`);
+    ids.add(source.id);
+    assert.match(source.url, /^https:\/\//);
+    for (const field of ['title', 'publisher', 'role', 'kind', 'accessed']) {
+      assert.ok(source[field], `${source.id} missing ${field}`);
+    }
+  }
+  assert.ok(data.sources.length >= 7);
+});
+
+test('housing page exposes every required chapter, lens, chart alternative, and possibility section', () => {
+  assert.match(html, /data-active="signals"/);
+  for (const id of ['where-now', 'direction', 'distribution', 'explanations', 'change-evidence', 'possibilities', 'sources']) {
+    assert.match(html, new RegExp(`id="${id}"`));
+  }
+  for (const lens of ['world', 'netherlands-europe', 'comparisons']) {
+    assert.match(html, new RegExp(`data-lens="${lens}"`));
+  }
+  assert.match(html, /housing-price-table/);
+  assert.match(html, /supply-table/);
+  assert.match(html, /Not an absolute affordability ranking/i);
+});
+
+test('all geographic evidence remains readable without JavaScript', () => {
+  const panels = [...html.matchAll(/<section\b[^>]*data-lens-panel="[^"]+"[^>]*>/g)].map((match) => match[0]);
+  assert.equal(panels.length, 3);
+  assert.ok(panels.every((panel) => !/\shidden(?:\s|=|>)/.test(panel)), 'lens panels must not be hidden in source HTML');
+  assert.match(html, /<noscript>[\s\S]*all geographic lenses are expanded/i);
+  assert.match(html, /<noscript>[\s\S]*\.lens-tabs\s*\{[^}]*display:\s*none\s*!important/i);
+  assert.match(script, /panel\.hidden = panel\.dataset\.lensPanel !== id/);
+});
+
+test('housing dashboard is dependency-free and renders baked data safely', () => {
+  assert.match(script, /data\/housing\.json/);
+  assert.match(script, /renderAffordabilityChart/);
+  assert.match(script, /renderSupplyChart/);
+  assert.match(script, /renderComparison/);
+  assert.match(script, /safeHttpsUrl/);
+  assert.doesNotMatch(script, /chart\.js|d3\.js|plotly/i);
+});

--- a/ctw.studio/signals/tests/roadmap.test.mjs
+++ b/ctw.studio/signals/tests/roadmap.test.mjs
@@ -1,0 +1,61 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const html = await readFile(new URL('roadmap/index.html', root), 'utf8');
+
+const topics = [
+  'Housing &amp; affordability',
+  'Prosperity',
+  'Energy &amp; compute',
+  'Healthspan &amp; care',
+  'Demography, migration &amp; aging',
+  'Democracy, trust &amp; information',
+  'Science &amp; discovery',
+  'Education &amp; human capability',
+  'Financial fragility',
+  'Global resilience'
+];
+
+test('roadmap publishes all ten subjects in the agreed order', () => {
+  let cursor = -1;
+  for (const topic of topics) {
+    const next = html.indexOf(topic);
+    assert.ok(next > cursor, `${topic} missing or out of order`);
+    cursor = next;
+  }
+});
+
+test('roadmap states the reusable evidence contract and geographic lenses', () => {
+  for (const question of [
+    'Where are we now?',
+    'What direction are we moving?',
+    'Who is benefiting or carrying the cost?',
+    'What are the competing explanations?',
+    'What evidence would change our current conclusion?'
+  ]) {
+    assert.match(html, new RegExp(question.replace(/[?]/g, '\\?')));
+  }
+  for (const lens of ['World', 'Europe / Netherlands', 'Selected countries']) {
+    assert.match(html, new RegExp(lens));
+  }
+  assert.match(html, /What might this make possible\?/);
+});
+
+test('roadmap links the published housing brief and labels publication status honestly', () => {
+  assert.match(html, /href="\.\.\/housing\/"/);
+  assert.match(html, /data-status="published"/);
+  assert.equal((html.match(/data-status="planned"/g) || []).length, 9);
+  assert.match(html, /<strong>3<\/strong>\s*briefings published/i);
+  assert.match(html, /<strong>1 of 10<\/strong>\s*atlas briefs published/i);
+  assert.match(html, /<strong>9<\/strong>\s*atlas briefs planned/i);
+});
+
+test('the preferred six-topic order is explicitly a first wave, not the complete atlas', () => {
+  assert.match(html, /Preferred first publication wave/i);
+  assert.match(html, /six-topic first wave/i);
+  for (const deferred of ['Democracy', 'Education', 'Financial fragility', 'Global resilience']) {
+    assert.match(html, new RegExp(deferred));
+  }
+});

--- a/ctw.studio/tailwind.config.js
+++ b/ctw.studio/tailwind.config.js
@@ -1,6 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 module.exports = {
-  content: ['./index.html', './portfolio/**/*.html', './workshop/**/*.html'],
+  content: ['./index.html', './nav.js', './portfolio/**/*.html', './workshop/**/*.html', './signals/**/*.html', './signals/**/*.js'],
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary

- add CTW Signals as a new evidence-led section in the global navigation
- publish Brief 001 on AI and work with baked labor-market data, contextual charts, and an auditable source ledger
- publish Brief 002 on food systems across animal lives, climate, land, water, oceans, and health
- publish Brief 003 on housing and affordability across World, Europe/Netherlands, and mechanism-led country comparisons
- standardize new briefs around five recurring questions, three geographic lenses, and an explicitly hypothetical “What might this make possible?” chapter
- add a ten-subject Signals atlas and the preferred first publication wave: Housing → Prosperity → Energy & Compute → Healthspan → Demography → Science
- add no-key data refresh scripts, integrity tests, responsive layouts, accessible tables, and keyboard-operable data views

## Housing evidence spine

- World Bank / UN-Habitat urban housing adequacy
- OECD analytical house-price, rent, price-to-income, and price-to-rent indices
- Eurostat tenure and housing-cost-overburden distributions
- CBS existing-home prices, dwelling-stock changes, and household formation
- ECB mortgage rates

Visitors read baked JSON; official endpoints are contacted only by the manual refresh scripts.

## Verification

- [x] `node --check signals/dashboard.js signals/food/food.js signals/housing/housing.js nav.js`
- [x] `node --test signals/tests/*.test.mjs` — 28/28 pass
- [x] `python3 -m py_compile signals/scripts/update_fred.py signals/scripts/update_food_data.py signals/scripts/update_housing_data.py`
- [x] housing updater rerun is byte-for-byte idempotent
- [x] `git diff --cached --check`
- [x] duplicate-ID and local route/asset validation for all Signals pages
- [x] HTTP 200 for Housing, roadmap, and baked housing JSON
- [x] desktop browser checks with no JavaScript console errors
- [x] 390px mobile checks with no document overflow
- [x] keyboard operation for the housing geographic-lens tabs
- [x] script-disabled browser check: inert tabs hidden and all three lens panels exposed
- [x] HTTPS validation before source URLs become clickable

## Notes

- Forecasts, estimates, observations, derived values, and hypotheses are labelled separately.
- Country bars use 2015=100 indices to compare change, not absolute affordability rankings.
- The world slum-population count is explicitly labelled as a derived estimate, not a direct census count; exact unrounded source inputs remain in the baked JSON so the headline can be recomputed.
- October 2025 U.S. unemployment remains explicitly unavailable because BLS did not publish it during the 2025 lapse in appropriations; the AI/work dashboard does not interpolate it.
- The repository-wide `Vercel – nlesc-portfolio` check failed on the prior commit although this branch changes no nlesc files. The same project check failed on preceding PR #143 while its `ctw.studio` preview passed; this appears to be an existing monorepo deployment issue rather than a Signals regression.
