### PR TITLE
Unify Signals Atlas subject navigation

### DIFF
--- a/ctw.studio/signals/README.md
+++ b/ctw.studio/signals/README.md
@@ -34,6 +34,8 @@ Atlas order, coverage and brief mapping:
 
 Current state: **9 published briefs**, **7 of 10 subjects with published coverage**, **3 planned subjects**. Coverage is not a completeness claim. All Atlas and brief-page subject pills use these root-relative anchors; each brief marks its mapped subject with `aria-current="location"`. The Signals brand links to `/signals/`.
 
+At 760px and below, `subject-menu.js` progressively enhances that same semantic navigation into a compact accessible disclosure. Without JavaScript, all ten links remain visible.
+
 ## Files
 
 - `index.html` and `atlas.css` — Signals Atlas homepage and ten-subject roadmap

--- a/ctw.studio/signals/README.md
+++ b/ctw.studio/signals/README.md
@@ -4,7 +4,7 @@ A lightweight, evidence-led dashboard inside `ctw.studio`. It treats important c
 
 ## Published briefs
 
-- **Signals atlas** (`index.html`) — the shared five-question evidence contract, three geographic lenses and the ten-subject publication roadmap.
+- **Signals atlas** (`index.html`) — the shared five-question evidence contract, three geographic lenses and canonical ten-subject taxonomy.
 - **Brief 001 · AI & work** (`ai-work/index.html`) — observed U.S. labor-market conditions, global AI exposure, early-career signals, employer expectations, adoption and productivity evidence.
 - **Brief 002 · Food, animals & the planet** (`food/index.html`) — animal slaughter, fish-count uncertainty, livestock emissions, product footprints, land, deforestation, water, oceans and health evidence.
 - **Brief 003 · Housing & affordability** (`housing/index.html`) — world housing adequacy, Dutch prices, rents, financing, tenure burden, supply and household formation, plus mechanism-led country comparisons.
@@ -14,6 +14,25 @@ A lightweight, evidence-led dashboard inside `ctw.studio`. It treats important c
 - **Brief 007 · Demography, migration & aging** (`demography/index.html`) — population stocks, migration flows, fertility, age structure, household formation, regional divergence and projections kept on their own clocks.
 - **Brief 008 · Education & human capability** (`education/index.html`) — assessments, pathways, adult learning, teacher capacity and bounded AI-tutor experiments without a synthetic capability score.
 - **Brief 009 · Financial fragility** (`financial-fragility/index.html`) — household, government, bank and pension balance sheets, flows, buffers and shock channels kept dimensionally separate.
+
+## Canonical subject taxonomy
+
+Atlas order, coverage and brief mapping:
+
+| # | Subject | Atlas anchor | Published briefs |
+|---|---|---|---|
+| 1 | Housing & affordability | `/signals/#subject-housing-affordability` | Brief 003 |
+| 2 | Food, animals & planet | `/signals/#subject-food-animals-planet` | Brief 002 |
+| 3 | Healthspan & care | `/signals/#subject-healthspan-care` | Brief 005 |
+| 4 | Work, education & human capability | `/signals/#subject-work-education-human-capability` | Briefs 001, 008 |
+| 5 | Prosperity & financial security | `/signals/#subject-prosperity-financial-security` | Brief 009 |
+| 6 | Energy, compute & infrastructure | `/signals/#subject-energy-compute-infrastructure` | Planned |
+| 7 | Demography, migration & aging | `/signals/#subject-demography-migration-aging` | Brief 007 |
+| 8 | Democracy, trust & information | `/signals/#subject-democracy-trust-information` | Planned |
+| 9 | Science, discovery & AI systems | `/signals/#subject-science-discovery-ai-systems` | Briefs 004, 006 |
+| 10 | Global resilience | `/signals/#subject-global-resilience` | Planned |
+
+Current state: **9 published briefs**, **7 of 10 subjects with published coverage**, **3 planned subjects**. Coverage is not a completeness claim. All Atlas and brief-page subject pills use these root-relative anchors; each brief marks its mapped subject with `aria-current="location"`. The Signals brand links to `/signals/`.
 
 ## Files
 

--- a/ctw.studio/signals/README.md
+++ b/ctw.studio/signals/README.md
@@ -32,9 +32,9 @@ Atlas order, coverage and brief mapping:
 | 9 | Science, discovery & AI systems | `/signals/#subject-science-discovery-ai-systems` | Briefs 004, 006 |
 | 10 | Global resilience | `/signals/#subject-global-resilience` | Planned |
 
-Current state: **9 published briefs**, **7 of 10 subjects with published coverage**, **3 planned subjects**. Coverage is not a completeness claim. All Atlas and brief-page subject pills use these root-relative anchors; each brief marks its mapped subject with `aria-current="location"`. The Signals brand links to `/signals/`.
+Current state: **9 published briefs**, **7 of 10 subjects with published coverage**, **3 planned subjects**. Coverage is not a completeness claim. Atlas and brief-page subject navigation uses seven canonical brief routes plus three visibly planned noninteractive rows; each brief marks its mapped subject with `aria-current="location"`. The Signals brand links to `/signals/`.
 
-At 760px and below, `subject-menu.js` progressively enhances that same semantic navigation into a compact accessible disclosure. Without JavaScript, all ten links remain visible.
+At 760px and below, `subject-menu.js` progressively enhances that same semantic navigation into a compact accessible disclosure. Without JavaScript, seven canonical links and three visibly planned noninteractive rows remain visible.
 
 ## Files
 

--- a/ctw.studio/signals/ai-work/index.html
+++ b/ctw.studio/signals/ai-work/index.html
@@ -35,16 +35,16 @@
       <div class="signal-shell">
         <nav class="topic-switcher" aria-label="CTW Signals subjects">
           <a class="signals-home topic-switcher__label" href="/signals/">CTW Signals</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill topic-pill--active" href="/signals/#subject-work-education-human-capability" aria-current="location">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill topic-pill--active" href="/signals/ai-work/" aria-current="location">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
 
         <div class="hero-grid">

--- a/ctw.studio/signals/ai-work/index.html
+++ b/ctw.studio/signals/ai-work/index.html
@@ -31,19 +31,19 @@
   <main id="main-content">
     <header class="signal-hero">
       <div class="signal-shell">
-        <div class="topic-switcher" aria-label="CTW Signals topics">
-          <span class="topic-switcher__label">CTW Signals</span>
-          <a class="topic-pill topic-pill--active" href="./" aria-current="page">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
-        </div>
+        <nav class="topic-switcher" aria-label="CTW Signals subjects">
+          <a class="signals-home topic-switcher__label" href="/signals/">CTW Signals</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill topic-pill--active" href="/signals/#subject-work-education-human-capability" aria-current="location">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+        </nav>
 
         <div class="hero-grid">
           <div class="hero-copy">

--- a/ctw.studio/signals/ai-work/index.html
+++ b/ctw.studio/signals/ai-work/index.html
@@ -18,11 +18,13 @@
   <link rel="apple-touch-icon" href="../../favicon.png">
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css?v=6">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap"></noscript>
   <script src="../dashboard.js" defer></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/atlas.css
+++ b/ctw.studio/signals/atlas.css
@@ -17,8 +17,8 @@
 .atlas-shell { width: min(1160px, calc(100% - 48px)); margin-inline: auto; }
 .atlas-hero { padding: 118px 0 90px; border-bottom: 1px solid var(--atlas-line); }
 .atlas-topics { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; padding-bottom: 78px; }
-.atlas-topics > span { flex: 0 0 auto; margin-right: 3px; color: var(--atlas-faint); font: 500 10px/1 var(--atlas-mono); letter-spacing: .12em; text-transform: uppercase; }
 .atlas-topics a { flex: 0 0 auto; padding: 8px 12px; border: 1px solid var(--atlas-line); border-radius: 99px; color: var(--atlas-muted); font: 500 10px/1 var(--atlas-mono); text-decoration: none; }
+.atlas-topics .atlas-brand { margin-right: 3px; padding-left: 0; border-color: transparent; color: var(--atlas-paper); letter-spacing: .12em; text-transform: uppercase; }
 .atlas-topics a:hover,
 .atlas-topics a:focus-visible { color: var(--atlas-paper); border-color: rgba(238,238,231,.3); }
 .atlas-topics .active { color: var(--atlas-green); border-color: rgba(186,217,159,.42); background: rgba(186,217,159,.07); }
@@ -57,16 +57,19 @@
 .topics-head { display: grid; grid-template-columns: 1fr 380px; gap: 60px; align-items: end; }
 .topics-head > p { margin: 0; }
 .atlas-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; margin: 0; padding: 0; list-style: none; }
-.atlas-card { min-height: 335px; border: 1px solid var(--atlas-line); background: rgba(15,17,14,.76); }
+.atlas-card { min-height: 335px; border: 1px solid var(--atlas-line); background: rgba(15,17,14,.76); scroll-margin-top: 110px; }
+.atlas-card:target { border-color: rgba(186,217,159,.72); }
 .atlas-card > div,
 .atlas-card > a { display: flex; flex-direction: column; min-height: 100%; padding: 32px; color: inherit; text-decoration: none; }
 .atlas-card header { display: flex; justify-content: space-between; gap: 20px; }
 .atlas-card header small { color: var(--atlas-faint); }
 .atlas-card h3 { margin: 58px 0 15px; font-size: 28px; letter-spacing: -.04em; }
 .atlas-card p { margin: 0; color: var(--atlas-muted); font-size: 14px; line-height: 1.67; }
-.atlas-card strong { display: block; margin-top: auto; padding-top: 27px; color: var(--atlas-green); font: 500 10px/1 var(--atlas-mono); text-transform: uppercase; }
+.atlas-card__links { display: grid; gap: 9px; margin-top: auto; padding-top: 27px; }
+.atlas-card__links a { padding-top: 10px; border-top: 1px solid var(--atlas-line); color: var(--atlas-green); font: 500 10px/1.35 var(--atlas-mono); text-decoration: none; text-transform: uppercase; }
+.atlas-card__links a:hover,
+.atlas-card__links a:focus-visible { color: var(--atlas-paper); border-color: rgba(186,217,159,.5); }
 .atlas-card--published { border-color: rgba(186,217,159,.38); background: linear-gradient(145deg, rgba(186,217,159,.08), rgba(15,17,14,.8)); }
-.atlas-card--published > a:hover { background: rgba(186,217,159,.035); }
 .path-note { max-width: 760px; margin: 22px 0 34px; color: var(--atlas-muted); font-size: 15px; line-height: 1.65; }
 .publication-path ol { display: grid; grid-template-columns: repeat(6, 1fr); margin: 0; padding: 0; border: solid var(--atlas-line); border-width: 1px 0; list-style: none; }
 .publication-path li { display: grid; min-height: 150px; padding: 23px 18px; border-right: 1px solid var(--atlas-line); }

--- a/ctw.studio/signals/atlas.css
+++ b/ctw.studio/signals/atlas.css
@@ -17,7 +17,10 @@
 .atlas-shell { width: min(1160px, calc(100% - 48px)); margin-inline: auto; }
 .atlas-hero { padding: 118px 0 90px; border-bottom: 1px solid var(--atlas-line); }
 .atlas-topics { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; padding-bottom: 78px; }
-.atlas-topics a { flex: 0 0 auto; padding: 8px 12px; border: 1px solid var(--atlas-line); border-radius: 99px; color: var(--atlas-muted); font: 500 10px/1 var(--atlas-mono); text-decoration: none; }
+.atlas-topics a,
+.atlas-topics .topic-pill--planned { display: flex; flex: 0 0 auto; align-items: center; gap: 7px; padding: 8px 12px; border: 1px solid var(--atlas-line); border-radius: 99px; color: var(--atlas-muted); font: 500 10px/1 var(--atlas-mono); text-decoration: none; }
+.atlas-topics .topic-pill--planned { border-style: dashed; color: var(--atlas-muted); }
+.atlas-topics .topic-pill__badge { color: var(--atlas-muted); font-size: 7px; letter-spacing: .08em; text-transform: uppercase; }
 .atlas-topics .atlas-brand { margin-right: 3px; padding-left: 0; border-color: transparent; color: var(--atlas-paper); letter-spacing: .12em; text-transform: uppercase; }
 .atlas-topics a:hover,
 .atlas-topics a:focus-visible { color: var(--atlas-paper); border-color: rgba(238,238,231,.3); }

--- a/ctw.studio/signals/demography/index.html
+++ b/ctw.studio/signals/demography/index.html
@@ -10,11 +10,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css?v=6">
   <link rel="stylesheet" href="demography.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="demography.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/demography/index.html
+++ b/ctw.studio/signals/demography/index.html
@@ -25,16 +25,16 @@
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill topic-pill--active" href="/signals/#subject-demography-migration-aging" aria-current="location">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill topic-pill--active" href="/signals/demography/" aria-current="location">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/demography/index.html
+++ b/ctw.studio/signals/demography/index.html
@@ -22,17 +22,17 @@
     <header class="evidence-hero demography-hero">
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
-          <span class="topic-switcher__label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill topic-pill--active" href="./" aria-current="page">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill topic-pill--active" href="/signals/#subject-demography-migration-aging" aria-current="location">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/education/index.html
+++ b/ctw.studio/signals/education/index.html
@@ -10,11 +10,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css?v=6">
   <link rel="stylesheet" href="education.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="education.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/education/index.html
+++ b/ctw.studio/signals/education/index.html
@@ -25,16 +25,16 @@
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill topic-pill--active" href="/signals/#subject-work-education-human-capability" aria-current="location">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill topic-pill--active" href="/signals/ai-work/" aria-current="location">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/education/index.html
+++ b/ctw.studio/signals/education/index.html
@@ -22,17 +22,17 @@
     <header class="evidence-hero">
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
-          <span class="topic-switcher__label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill topic-pill--active" href="./" aria-current="page">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill topic-pill--active" href="/signals/#subject-work-education-human-capability" aria-current="location">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/financial-fragility/financial-fragility.css
+++ b/ctw.studio/signals/financial-fragility/financial-fragility.css
@@ -72,7 +72,7 @@
   flex-wrap: wrap;
   gap: 7px;
   align-items: center;
-  padding: 24px 0;
+  padding: 118px 0 24px;
   font-family: var(--ff-mono);
   font-size: 11px;
 }
@@ -1076,8 +1076,8 @@
   }
 
   .fragility-topics {
-    overflow-x: auto;
-    flex-wrap: nowrap;
+    overflow-x: visible;
+    flex-wrap: wrap;
     padding-bottom: 12px;
   }
 

--- a/ctw.studio/signals/financial-fragility/index.html
+++ b/ctw.studio/signals/financial-fragility/index.html
@@ -26,16 +26,16 @@
       <div class="signal-shell">
         <nav class="topic-switcher fragility-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill topic-pill--active fragility-active" href="/signals/#subject-prosperity-financial-security" aria-current="location">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill topic-pill--active fragility-active" href="/signals/financial-fragility/" aria-current="location">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
 
         <div class="fragility-hero-grid">

--- a/ctw.studio/signals/financial-fragility/index.html
+++ b/ctw.studio/signals/financial-fragility/index.html
@@ -10,11 +10,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css">
   <link rel="stylesheet" href="financial-fragility.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="financial-fragility.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/financial-fragility/index.html
+++ b/ctw.studio/signals/financial-fragility/index.html
@@ -23,17 +23,17 @@
     <header class="fragility-hero" aria-labelledby="page-title">
       <div class="signal-shell">
         <nav class="topic-switcher fragility-topics" aria-label="Signal topics">
-          <span class="topic-label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill fragility-active" href="./" aria-current="page">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill topic-pill--active fragility-active" href="/signals/#subject-prosperity-financial-security" aria-current="location">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
 
         <div class="fragility-hero-grid">

--- a/ctw.studio/signals/food/index.html
+++ b/ctw.studio/signals/food/index.html
@@ -36,16 +36,16 @@
       <div class="signal-shell">
         <nav class="topic-switcher" aria-label="Signal subjects">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill topic-pill--active active food-active" href="/signals/#subject-food-animals-planet" aria-current="location">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill topic-pill--active active food-active" href="/signals/food/" aria-current="location">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
 
         <div class="hero-grid">

--- a/ctw.studio/signals/food/index.html
+++ b/ctw.studio/signals/food/index.html
@@ -32,19 +32,19 @@
   <main id="main-content">
     <section class="signal-hero food-hero" aria-labelledby="page-title">
       <div class="signal-shell">
-        <div class="topic-switcher" aria-label="Signal topics">
-          <span class="topic-label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill active food-active" href="./" aria-current="page">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
-        </div>
+        <nav class="topic-switcher" aria-label="Signal subjects">
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill topic-pill--active active food-active" href="/signals/#subject-food-animals-planet" aria-current="location">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+        </nav>
 
         <div class="hero-grid">
           <div class="hero-copy reveal">

--- a/ctw.studio/signals/food/index.html
+++ b/ctw.studio/signals/food/index.html
@@ -18,12 +18,14 @@
   <link href="../../tailwind.css" rel="stylesheet">
   <link href="../signals.css" rel="stylesheet">
   <link href="food.css" rel="stylesheet">
+  <link href="../subject-menu.css" rel="stylesheet">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" media="print" onload="this.media='all'">
   <noscript><link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap"></noscript>
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="food.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/healthspan/index.html
+++ b/ctw.studio/signals/healthspan/index.html
@@ -10,11 +10,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css?v=6">
   <link rel="stylesheet" href="healthspan.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="healthspan.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/healthspan/index.html
+++ b/ctw.studio/signals/healthspan/index.html
@@ -22,8 +22,17 @@
     <header class="evidence-hero">
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
-          <span class="topic-switcher__label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a><a class="topic-pill" href="../food/">Food &amp; planet</a><a class="topic-pill" href="../housing/">Housing</a><a class="topic-pill" href="../science/">Science</a><a class="topic-pill topic-pill--active" href="./" aria-current="page">Healthspan</a><a class="topic-pill" href="../real-time-ai/">Real-time AI</a><a class="topic-pill" href="../demography/">Demography</a><a class="topic-pill" href="../education/">Education</a><a class="topic-pill" href="../financial-fragility/">Financial fragility</a><a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill topic-pill--active" href="/signals/#subject-healthspan-care" aria-current="location">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/healthspan/index.html
+++ b/ctw.studio/signals/healthspan/index.html
@@ -25,16 +25,16 @@
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill topic-pill--active" href="/signals/#subject-healthspan-care" aria-current="location">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill topic-pill--active" href="/signals/healthspan/" aria-current="location">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/housing/housing.css
+++ b/ctw.studio/signals/housing/housing.css
@@ -72,14 +72,12 @@
 
 .housing-topics {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 7px;
-  overflow-x: auto;
+  overflow-x: visible;
   padding: 3px 0 52px;
-  scrollbar-width: none;
 }
-
-.housing-topics::-webkit-scrollbar { display: none; }
 
 .housing-topics .topic-label {
   flex: 0 0 auto;

--- a/ctw.studio/signals/housing/index.html
+++ b/ctw.studio/signals/housing/index.html
@@ -10,11 +10,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css">
   <link rel="stylesheet" href="housing.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="housing.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/housing/index.html
+++ b/ctw.studio/signals/housing/index.html
@@ -23,17 +23,17 @@
     <header class="housing-hero" aria-labelledby="page-title">
       <div class="signal-shell">
         <nav class="topic-switcher housing-topics" aria-label="Signal topics">
-          <span class="topic-label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food &amp; planet</a>
-          <a class="topic-pill housing-active" href="./" aria-current="page">Housing</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill topic-pill--active housing-active" href="/signals/#subject-housing-affordability" aria-current="location">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
 
         <div class="housing-hero-grid">
@@ -307,8 +307,8 @@
         </section>
 
         <a class="roadmap-cta reveal" href="../">
-          <span><small>Signals atlas</small><strong>See the next ten briefings →</strong></span>
-          <span>Housing → Prosperity → Energy &amp; Compute → Healthspan → Demography → Science</span>
+          <span><small>Signals atlas</small><strong>Explore the ten subjects →</strong></span>
+          <span>Seven subjects with published coverage · three planned</span>
         </a>
       </article>
     </div>

--- a/ctw.studio/signals/housing/index.html
+++ b/ctw.studio/signals/housing/index.html
@@ -26,16 +26,16 @@
       <div class="signal-shell">
         <nav class="topic-switcher housing-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill topic-pill--active housing-active" href="/signals/#subject-housing-affordability" aria-current="location">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill" href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill topic-pill--active housing-active" href="/signals/housing/" aria-current="location">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
 
         <div class="housing-hero-grid">

--- a/ctw.studio/signals/index.html
+++ b/ctw.studio/signals/index.html
@@ -29,16 +29,16 @@
       <div class="atlas-shell">
         <nav class="atlas-topics" aria-label="Signal subjects">
           <a class="signals-home atlas-brand" href="/signals/">Signals /</a>
-          <a href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
-          <a href="/signals/#subject-global-resilience">Global resilience</a>
+          <a href="/signals/housing/">Housing &amp; affordability</a>
+          <a href="/signals/food/">Food, animals &amp; planet</a>
+          <a href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
         <p class="atlas-kicker">The Signals atlas · Version 1</p>
         <h1>Important questions,<br><em>held to one standard.</em></h1>

--- a/ctw.studio/signals/index.html
+++ b/ctw.studio/signals/index.html
@@ -4,11 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Signals atlas — CTW Signals</title>
-  <meta name="description" content="The evidence standard, geographic lenses and publication roadmap for ten CTW Signals briefings.">
+  <meta name="description" content="The evidence standard, geographic lenses and canonical taxonomy for ten CTW Signals subjects.">
   <meta name="theme-color" content="#080907">
   <link rel="canonical" href="https://ctw.studio/signals/">
   <meta property="og:title" content="The Signals atlas — CTW Signals">
-  <meta property="og:description" content="Ten long-horizon evidence briefs held to one inspectable standard.">
+  <meta property="og:description" content="Ten long-horizon subjects held to one inspectable evidence standard.">
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://ctw.studio/signals/">
   <link rel="icon" href="../favicon.png">
@@ -25,26 +25,26 @@
   <main id="main-content">
     <header class="atlas-hero">
       <div class="atlas-shell">
-        <nav class="atlas-topics" aria-label="Signal topics">
-          <span>Signals /</span>
-          <a href="ai-work/">AI &amp; work</a>
-          <a href="food/">Food &amp; planet</a>
-          <a href="housing/">Housing</a>
-          <a href="science/">Science</a>
-          <a href="healthspan/">Healthspan</a>
-          <a href="real-time-ai/">Real-time AI</a>
-          <a href="demography/">Demography</a>
-          <a href="education/">Education</a>
-          <a href="financial-fragility/">Financial fragility</a>
-          <a class="active" href="./" aria-current="page">Atlas</a>
+        <nav class="atlas-topics" aria-label="Signal subjects">
+          <a class="signals-home atlas-brand" href="/signals/">Signals /</a>
+          <a href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a href="/signals/#subject-science-discovery-ai-systems">Science, discovery &amp; AI systems</a>
+          <a href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
         <p class="atlas-kicker">The Signals atlas · Version 1</p>
         <h1>Important questions,<br><em>held to one standard.</em></h1>
-        <p class="atlas-deck">Ten long-horizon briefings about whether life is becoming more capable, affordable, healthy, resilient and free—not a scoreboard of context-free metrics.</p>
+        <p class="atlas-deck">Ten long-horizon subjects asking whether life is becoming more capable, affordable, healthy, resilient and free—not a scoreboard of context-free metrics.</p>
         <div class="atlas-status">
-          <span><strong>9</strong> briefings published</span>
-          <span><strong>6 of 10</strong> atlas briefs published</span>
-          <span><strong>4</strong> atlas briefs planned</span>
+          <span><strong>9</strong> published briefs</span>
+          <span><strong>7 of 10</strong> subjects with published coverage</span>
+          <span><strong>3</strong> subjects planned</span>
         </div>
       </div>
     </header>
@@ -53,82 +53,89 @@
       <div class="atlas-shell">
         <div class="section-head topics-head">
           <div><p class="section-label">The ten-subject atlas</p><h2 id="topics-title">What Signals will track.</h2></div>
-          <p>Each card defines a standing evidence brief, not a one-off article. The indicators can evolve; the question remains inspectable.</p>
+          <p>Each card defines a standing subject, not a claim of complete coverage. Briefs can accumulate; indicators can evolve; each question remains inspectable.</p>
         </div>
 
         <ol class="atlas-grid">
-          <li class="atlas-card atlas-card--published" data-status="published">
-            <a href="housing/">
-              <header><span>01</span><small>Published · Brief 003</small></header>
+          <li id="subject-housing-affordability" class="atlas-card atlas-card--published" data-status="published">
+            <div>
+              <header><span>01</span><small>Published coverage</small></header>
               <h3>Housing &amp; affordability</h3>
               <p>Track prices against incomes, rents, mortgage costs and total monthly burden; construction against household formation; social housing, waiting times, homelessness, vacancy and who gains from scarcity.</p>
-              <strong>Read the brief →</strong>
-            </a>
-          </li>
-          <li class="atlas-card" data-status="planned">
-            <div>
-              <header><span>02</span><small>Planned · Next</small></header>
-              <h3>Prosperity</h3>
-              <p>Track median disposable income, productivity, real wages, essential costs, wealth distribution, public services, time use and whether economic gains reach ordinary households.</p>
+              <div class="atlas-card__links"><a href="housing/">Brief 003 · Housing &amp; affordability →</a></div>
             </div>
           </li>
-          <li class="atlas-card" data-status="planned">
+          <li id="subject-food-animals-planet" class="atlas-card atlas-card--published" data-status="published">
             <div>
-              <header><span>03</span><small>Planned</small></header>
-              <h3>Energy &amp; compute</h3>
+              <header><span>02</span><small>Published coverage</small></header>
+              <h3>Food, animals &amp; planet</h3>
+              <p>Track animal lives, land, emissions, forests, water, oceans, health and uncertainty without collapsing distinct system boundaries.</p>
+              <div class="atlas-card__links"><a href="food/">Brief 002 · Food, animals &amp; planet →</a></div>
+            </div>
+          </li>
+          <li id="subject-healthspan-care" class="atlas-card atlas-card--published" data-status="published">
+            <div>
+              <header><span>03</span><small>Published coverage</small></header>
+              <h3>Healthspan &amp; care</h3>
+              <p>Track healthy life years, preventable mortality, chronic and mental illness, access and waiting times, workforce capacity, antimicrobial resistance and whether longer lives are better lives.</p>
+              <div class="atlas-card__links"><a href="healthspan/">Brief 005 · Healthspan &amp; care →</a></div>
+            </div>
+          </li>
+          <li id="subject-work-education-human-capability" class="atlas-card atlas-card--published" data-status="published">
+            <div>
+              <header><span>04</span><small>Published coverage · 2 briefs</small></header>
+              <h3>Work, education &amp; human capability</h3>
+              <p>Track labour-market change, task exposure, learning outcomes, pathways, adult retraining, teacher capacity and whether technology expands human capability.</p>
+              <div class="atlas-card__links">
+                <a href="ai-work/">Brief 001 · AI &amp; work →</a>
+                <a href="education/">Brief 008 · Education &amp; human capability →</a>
+              </div>
+            </div>
+          </li>
+          <li id="subject-prosperity-financial-security" class="atlas-card atlas-card--published" data-status="published">
+            <div>
+              <header><span>05</span><small>Published coverage</small></header>
+              <h3>Prosperity &amp; financial security</h3>
+              <p>Track incomes, wages, essential costs, wealth, debt, savings, public finance and whether economic gains and financial buffers reach ordinary households.</p>
+              <div class="atlas-card__links"><a href="financial-fragility/">Brief 009 · Financial fragility →</a></div>
+            </div>
+          </li>
+          <li id="subject-energy-compute-infrastructure" class="atlas-card" data-status="planned">
+            <div>
+              <header><span>06</span><small>Planned subject</small></header>
+              <h3>Energy, compute &amp; infrastructure</h3>
               <p>Track demand, prices, grid congestion, clean generation, firm capacity, storage, transmission, data centres, AI load, emissions and which constraints are physical rather than rhetorical.</p>
             </div>
           </li>
-          <li class="atlas-card atlas-card--published" data-status="published">
-            <a href="healthspan/">
-              <header><span>04</span><small>Published · Brief 005</small></header>
-              <h3>Healthspan &amp; care</h3>
-              <p>Track healthy life years, preventable mortality, chronic and mental illness, access and waiting times, workforce capacity, antimicrobial resistance and whether longer lives are better lives.</p>
-              <strong>Read the brief →</strong>
-            </a>
-          </li>
-          <li class="atlas-card atlas-card--published" data-status="published">
-            <a href="demography/">
-              <header><span>05</span><small>Published · Brief 007</small></header>
+          <li id="subject-demography-migration-aging" class="atlas-card atlas-card--published" data-status="published">
+            <div>
+              <header><span>07</span><small>Published coverage</small></header>
               <h3>Demography, migration &amp; aging</h3>
               <p>Track fertility, age structure, migration, dependency, household formation, regional divergence, integration and what population change means for housing, care, work and public finance.</p>
-              <strong>Read the brief →</strong>
-            </a>
+              <div class="atlas-card__links"><a href="demography/">Brief 007 · Demography, migration &amp; aging →</a></div>
+            </div>
           </li>
-          <li class="atlas-card" data-status="planned">
+          <li id="subject-democracy-trust-information" class="atlas-card" data-status="planned">
             <div>
-              <header><span>06</span><small>Planned</small></header>
+              <header><span>08</span><small>Planned subject</small></header>
               <h3>Democracy, trust &amp; information</h3>
               <p>Track institutional trust, rule of law, corruption, turnout, polarization, press freedom, information concentration, online manipulation and how AI-mediated discovery changes public knowledge.</p>
             </div>
           </li>
-          <li class="atlas-card atlas-card--published" data-status="published">
-            <a href="science/">
-              <header><span>07</span><small>Published · Brief 004</small></header>
-              <h3>Science &amp; discovery</h3>
-              <p>Track R&amp;D investment, research concentration, open data and software, replication, clinical translation, drug-development time, public research capacity, and whether AI measurably accelerates discovery rather than merely increasing publication volume.</p>
-              <strong>Read the brief →</strong>
-            </a>
-          </li>
-          <li class="atlas-card atlas-card--published" data-status="published">
-            <a href="education/">
-              <header><span>08</span><small>Published · Brief 008</small></header>
-              <h3>Education &amp; human capability</h3>
-              <p>Track foundational literacy and numeracy, learning loss, vocational pathways, adult retraining, education costs, teacher shortages, skill mismatches, and whether AI tutors improve outcomes.</p>
-              <strong>Read the brief →</strong>
-            </a>
-          </li>
-          <li class="atlas-card atlas-card--published" data-status="published">
-            <a href="financial-fragility/">
-              <header><span>09</span><small>Published · Brief 009</small></header>
-              <h3>Financial fragility</h3>
-              <p>Track household debt, government interest burden, credit stress, savings, asset-price-to-income ratios, bank stability, pension adequacy, and who is exposed when rates or prices move.</p>
-              <strong>Read the brief →</strong>
-            </a>
-          </li>
-          <li class="atlas-card" data-status="planned">
+          <li id="subject-science-discovery-ai-systems" class="atlas-card atlas-card--published" data-status="published">
             <div>
-              <header><span>10</span><small>Planned</small></header>
+              <header><span>09</span><small>Published coverage · 2 briefs</small></header>
+              <h3>Science, discovery &amp; AI systems</h3>
+              <p>Track research inputs, reliability, translation and demonstrated AI acceleration alongside bounded AI systems, field operation and retained human work.</p>
+              <div class="atlas-card__links">
+                <a href="science/">Brief 004 · Science &amp; discovery →</a>
+                <a href="real-time-ai/">Brief 006 · Real-time AI →</a>
+              </div>
+            </div>
+          </li>
+          <li id="subject-global-resilience" class="atlas-card" data-status="planned">
+            <div>
+              <header><span>10</span><small>Planned subject</small></header>
               <h3>Global resilience</h3>
               <p>Track conflict, displacement, food and energy exposure, supply-chain concentration, critical minerals, semiconductor dependencies, disaster losses, insurance retreat, and adaptation investment.</p>
             </div>
@@ -171,15 +178,15 @@
 
     <section class="publication-path" aria-labelledby="path-title">
       <div class="atlas-shell">
-        <div class="section-head"><p class="section-label">Preferred first publication wave</p><h2 id="path-title">Build depth before breadth.</h2></div>
-        <p class="path-note">This six-topic sequence remains the preferred depth-first path, but publication now extends beyond it: Education and Financial fragility are live. Prosperity, Energy, Democracy and Global resilience remain planned; the complete atlas is not yet published.</p>
+        <div class="section-head"><p class="section-label">Original six-subject first wave</p><h2 id="path-title">Build depth before breadth.</h2></div>
+        <p class="path-note">This first-wave sequence still guides depth, while published coverage now spans seven canonical subjects. Coverage is a foundation, not completion. Energy, compute &amp; infrastructure remains planned; Democracy, trust &amp; information and Global resilience are also planned outside this wave.</p>
         <ol>
-          <li class="done"><span>01</span><strong>Housing</strong><small>Published</small></li>
-          <li><span>02</span><strong>Prosperity</strong><small>Next</small></li>
-          <li><span>03</span><strong>Energy &amp; Compute</strong><small>Queued</small></li>
-          <li class="done"><span>04</span><strong>Healthspan</strong><small>Published</small></li>
-          <li class="done"><span>05</span><strong>Demography</strong><small>Published</small></li>
-          <li class="done"><span>06</span><strong>Science</strong><small>Published</small></li>
+          <li class="done"><span>01</span><strong>Housing &amp; affordability</strong><small>Coverage published</small></li>
+          <li class="done"><span>02</span><strong>Prosperity &amp; financial security</strong><small>Coverage published</small></li>
+          <li><span>03</span><strong>Energy, compute &amp; infrastructure</strong><small>Planned</small></li>
+          <li class="done"><span>04</span><strong>Healthspan &amp; care</strong><small>Coverage published</small></li>
+          <li class="done"><span>05</span><strong>Demography, migration &amp; aging</strong><small>Coverage published</small></li>
+          <li class="done"><span>06</span><strong>Science, discovery &amp; AI systems</strong><small>Coverage published</small></li>
         </ol>
       </div>
     </section>

--- a/ctw.studio/signals/index.html
+++ b/ctw.studio/signals/index.html
@@ -15,10 +15,12 @@
   <link rel="stylesheet" href="../tailwind.css">
   <link rel="stylesheet" href="signals.css">
   <link rel="stylesheet" href="atlas.css">
+  <link rel="stylesheet" href="subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../nav.js" data-base="../" data-active="signals"></script>
+  <script defer src="subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the atlas</a>

--- a/ctw.studio/signals/real-time-ai/index.html
+++ b/ctw.studio/signals/real-time-ai/index.html
@@ -23,17 +23,17 @@
     <header class="evidence-hero realtime-hero">
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
-          <span class="topic-switcher__label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing</a>
-          <a class="topic-pill" href="../science/">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill topic-pill--active" href="./" aria-current="page">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill topic-pill--active" href="/signals/#subject-science-discovery-ai-systems" aria-current="location">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/real-time-ai/index.html
+++ b/ctw.studio/signals/real-time-ai/index.html
@@ -11,11 +11,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css?v=6">
   <link rel="stylesheet" href="real-time-ai.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="real-time-ai.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/real-time-ai/index.html
+++ b/ctw.studio/signals/real-time-ai/index.html
@@ -26,16 +26,16 @@
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill topic-pill--active" href="/signals/#subject-science-discovery-ai-systems" aria-current="location">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill topic-pill--active" href="/signals/science/" aria-current="location">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/science/index.html
+++ b/ctw.studio/signals/science/index.html
@@ -22,17 +22,17 @@
     <header class="evidence-hero">
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
-          <span class="topic-switcher__label">Signals /</span>
-          <a class="topic-pill" href="../ai-work/">AI &amp; work</a>
-          <a class="topic-pill" href="../food/">Food &amp; planet</a>
-          <a class="topic-pill" href="../housing/">Housing</a>
-          <a class="topic-pill topic-pill--active" href="./" aria-current="page">Science</a>
-          <a class="topic-pill" href="../healthspan/">Healthspan</a>
-          <a class="topic-pill" href="../real-time-ai/">Real-time AI</a>
-          <a class="topic-pill" href="../demography/">Demography</a>
-          <a class="topic-pill" href="../education/">Education</a>
-          <a class="topic-pill" href="../financial-fragility/">Financial fragility</a>
-          <a class="topic-pill" href="../">Atlas</a>
+          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
+          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
+          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
+          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
+          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
+          <a class="topic-pill topic-pill--active" href="/signals/#subject-science-discovery-ai-systems" aria-current="location">Science, discovery &amp; AI systems</a>
+          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/science/index.html
+++ b/ctw.studio/signals/science/index.html
@@ -25,16 +25,16 @@
       <div class="signal-shell">
         <nav class="evidence-topics" aria-label="Signal topics">
           <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/#subject-housing-affordability">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/#subject-food-animals-planet">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/#subject-healthspan-care">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/#subject-work-education-human-capability">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/#subject-prosperity-financial-security">Prosperity &amp; financial security</a>
-          <a class="topic-pill" href="/signals/#subject-energy-compute-infrastructure">Energy, compute &amp; infrastructure</a>
-          <a class="topic-pill" href="/signals/#subject-demography-migration-aging">Demography, migration &amp; aging</a>
-          <a class="topic-pill" href="/signals/#subject-democracy-trust-information">Democracy, trust &amp; information</a>
-          <a class="topic-pill topic-pill--active" href="/signals/#subject-science-discovery-ai-systems" aria-current="location">Science, discovery &amp; AI systems</a>
-          <a class="topic-pill" href="/signals/#subject-global-resilience">Global resilience</a>
+          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
+          <a class="topic-pill topic-pill--active" href="/signals/science/" aria-current="location">Science, discovery &amp; AI systems</a>
+          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/science/index.html
+++ b/ctw.studio/signals/science/index.html
@@ -10,11 +10,13 @@
   <link rel="stylesheet" href="../../tailwind.css">
   <link rel="stylesheet" href="../signals.css?v=6">
   <link rel="stylesheet" href="science.css">
+  <link rel="stylesheet" href="../subject-menu.css">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=DM+Mono:wght@400;500&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
   <script defer src="../../nav.js" data-base="../../" data-active="signals"></script>
   <script defer src="science.js"></script>
+  <script defer src="../subject-menu.js"></script>
 </head>
 <body>
   <a class="skip-link" href="#main-content">Skip to the evidence</a>

--- a/ctw.studio/signals/signals.css
+++ b/ctw.studio/signals/signals.css
@@ -64,8 +64,10 @@ button { font: inherit; }
 .topic-switcher {
   position: relative;
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: 0.65rem;
+  overflow-x: visible;
   margin-bottom: clamp(3rem, 7vw, 6rem);
   color: var(--muted);
   font-family: var(--mono);
@@ -73,6 +75,11 @@ button { font: inherit; }
   letter-spacing: 0.04em;
   text-transform: uppercase;
 }
+.signals-home,
+.topic-pill { flex: 0 0 auto; }
+.signals-home { color: var(--ink); font-weight: 500; text-decoration: none; }
+.signals-home:hover,
+.signals-home:focus-visible { color: var(--amber); }
 .topic-switcher__label { margin-right: 0.7rem; color: var(--ink); font-weight: 500; }
 .topic-pill { padding: 0.42rem 0.75rem; border: 1px solid var(--line); border-radius: 999px; text-decoration: none; }
 .topic-pill--active { border-color: rgba(247,181,0,0.45); background: rgba(247,181,0,0.09); color: var(--amber); }
@@ -157,13 +164,12 @@ button { font: inherit; }
 .evidence-hero { padding: 8rem 0 4rem; border-bottom: 1px solid var(--line); }
 .evidence-topics {
   display: flex;
+  flex-wrap: wrap;
   gap: .45rem;
   align-items: center;
-  overflow-x: auto;
+  overflow-x: visible;
   padding-bottom: 4rem;
-  scrollbar-width: none;
 }
-.evidence-topics::-webkit-scrollbar { display: none; }
 .evidence-topics .topic-pill { flex: 0 0 auto; font-size: .66rem; }
 .evidence-topics .topic-pill--active {
   border-color: rgba(var(--topic-rgb), .5);
@@ -380,7 +386,7 @@ button { font: inherit; }
     margin-inline: 0;
     padding-inline: 0;
   }
-  .evidence-topics .topic-switcher__label { width: 100%; }
+  .evidence-topics .topic-switcher__label { width: auto; }
   .evidence-hero h1 { font-size: clamp(2.75rem, 15vw, 4.4rem); }
   .lens-grid,
   .dimension-grid,
@@ -651,8 +657,8 @@ button { font: inherit; }
 @media (max-width: 760px) {
   .signal-shell { width: min(100% - 2rem, 1480px); }
   .signal-hero { padding-top: 7.2rem; }
-  .topic-switcher { align-items: flex-start; flex-wrap: wrap; margin-bottom: 3.5rem; }
-  .topic-switcher__label { width: 100%; margin-bottom: .2rem; }
+  .topic-switcher { align-items: center; margin-bottom: 3.5rem; }
+  .topic-switcher__label { width: auto; margin-bottom: 0; }
   .topic-pill--future { display: none; }
   .hero-copy h1 { font-size: clamp(3rem, 15vw, 5.5rem); }
   .hero-question-row { grid-template-columns: 1fr 1fr; }

--- a/ctw.studio/signals/subject-menu.css
+++ b/ctw.studio/signals/subject-menu.css
@@ -6,6 +6,12 @@
   display: contents;
 }
 
+.topic-pill--planned {
+  cursor: default;
+  opacity: 1;
+  pointer-events: none;
+}
+
 @media (max-width: 760px) {
   .subject-menu-ready .subject-menu {
     --subject-menu-surface: #0b0c0a;
@@ -93,11 +99,13 @@
     display: grid;
   }
 
-  .subject-menu-ready .subject-menu__panel a {
+  .subject-menu-ready .subject-menu__panel > :is(a, .topic-pill--planned) {
     display: flex;
     min-width: 0;
     min-height: 44px;
     align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
     padding: 0.7rem 0.8rem;
     border: 0;
     border-radius: 0.65rem;
@@ -108,6 +116,19 @@
     transition: none;
     white-space: normal;
     overflow-wrap: anywhere;
+  }
+
+  .subject-menu-ready .subject-menu__panel > .topic-pill--planned {
+    color: color-mix(in srgb, var(--subject-menu-text) 65%, transparent);
+    cursor: default;
+  }
+
+  .subject-menu-ready .topic-pill__badge {
+    flex: 0 0 auto;
+    color: color-mix(in srgb, var(--subject-menu-text) 55%, transparent);
+    font: 500 0.68rem/1 var(--subject-menu-font);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
   }
 
   .subject-menu-ready .subject-menu__panel a:not([aria-current="location"]):hover {

--- a/ctw.studio/signals/subject-menu.css
+++ b/ctw.studio/signals/subject-menu.css
@@ -86,8 +86,13 @@
     padding: 0.7rem 0.8rem;
     border: 0;
     border-radius: 0.65rem;
+    font: inherit;
     white-space: normal;
     overflow-wrap: anywhere;
+  }
+
+  .subject-menu-ready .subject-menu__panel :where(a:not([aria-current="location"])) {
+    color: inherit;
   }
 
   .subject-menu-open .ctw-feedback-button {

--- a/ctw.studio/signals/subject-menu.css
+++ b/ctw.studio/signals/subject-menu.css
@@ -8,6 +8,12 @@
 
 @media (max-width: 760px) {
   .subject-menu-ready .subject-menu {
+    --subject-menu-surface: #0b0c0a;
+    --subject-menu-text: #f4f1e8;
+    --subject-menu-border: rgba(255, 255, 255, 0.36);
+    --subject-menu-accent: #f7b500;
+    --subject-menu-accent-soft: rgba(247, 181, 0, 0.11);
+    --subject-menu-font: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     position: relative;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
@@ -30,12 +36,15 @@
     justify-content: space-between;
     gap: 0.75rem;
     padding: 0.65rem 0.85rem;
-    border: 1px solid rgba(255, 255, 255, 0.22);
+    border: 1px solid var(--subject-menu-border);
     border-radius: 999px;
-    background: rgba(8, 9, 7, 0.96);
-    color: inherit;
-    font: inherit;
+    background: var(--subject-menu-surface);
+    color: var(--subject-menu-text);
+    font: 500 1rem/1.35 var(--subject-menu-font);
+    letter-spacing: normal;
     text-align: left;
+    text-transform: none;
+    transition: none;
     cursor: pointer;
   }
 
@@ -46,12 +55,14 @@
   }
 
   .subject-menu-ready .subject-menu__trigger[aria-expanded="true"] {
-    border-color: currentColor;
+    border-color: var(--subject-menu-accent);
   }
 
   .subject-menu-ready .subject-menu__trigger:focus-visible,
   .subject-menu-ready .subject-menu__panel a:focus-visible {
-    outline: 3px solid currentColor;
+    border-color: var(--subject-menu-accent);
+    color: var(--subject-menu-text);
+    outline: 3px solid var(--subject-menu-accent);
     outline-offset: 2px;
   }
 
@@ -68,10 +79,14 @@
     overflow-y: auto;
     overscroll-behavior: contain;
     padding: 0.4rem;
-    border: 1px solid rgba(255, 255, 255, 0.22);
+    border: 1px solid var(--subject-menu-border);
     border-radius: 1rem;
-    background: #0b0c0a;
+    background: var(--subject-menu-surface);
+    color: var(--subject-menu-text);
+    font: 500 1rem/1.35 var(--subject-menu-font);
+    letter-spacing: normal;
     box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.5);
+    text-transform: none;
   }
 
   .subject-menu-ready .subject-menu__panel[aria-hidden="false"] {
@@ -86,13 +101,26 @@
     padding: 0.7rem 0.8rem;
     border: 0;
     border-radius: 0.65rem;
-    font: inherit;
+    color: var(--subject-menu-text);
+    font: 500 1rem/1.35 var(--subject-menu-font);
+    letter-spacing: normal;
+    text-transform: none;
+    transition: none;
     white-space: normal;
     overflow-wrap: anywhere;
   }
 
-  .subject-menu-ready .subject-menu__panel :where(a:not([aria-current="location"])) {
-    color: inherit;
+  .subject-menu-ready .subject-menu__panel a:not([aria-current="location"]):hover {
+    background: rgba(255, 255, 255, 0.07);
+    border-color: var(--subject-menu-border);
+    color: var(--subject-menu-text);
+  }
+
+  .subject-menu-ready .subject-menu__panel a[aria-current="location"] {
+    background: var(--subject-menu-accent-soft) !important;
+    border-color: var(--subject-menu-accent) !important;
+    color: var(--subject-menu-accent) !important;
+    box-shadow: inset 0 0 0 1px var(--subject-menu-accent);
   }
 
   .subject-menu-open .ctw-feedback-button {

--- a/ctw.studio/signals/subject-menu.css
+++ b/ctw.studio/signals/subject-menu.css
@@ -1,0 +1,97 @@
+.subject-menu__trigger {
+  display: none;
+}
+
+.subject-menu__panel {
+  display: contents;
+}
+
+@media (max-width: 760px) {
+  .subject-menu-ready .subject-menu {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: center;
+    gap: 0.75rem;
+    margin-bottom: 3.5rem;
+    padding-bottom: 0;
+  }
+
+  .subject-menu-ready .subject-menu .signals-home {
+    width: auto;
+    margin: 0;
+  }
+
+  .subject-menu-ready .subject-menu__trigger {
+    display: flex;
+    min-width: 0;
+    min-height: 44px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.65rem 0.85rem;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 999px;
+    background: rgba(8, 9, 7, 0.96);
+    color: inherit;
+    font: inherit;
+    text-align: left;
+    cursor: pointer;
+  }
+
+  .subject-menu-ready .subject-menu__trigger-label {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .subject-menu-ready .subject-menu__trigger[aria-expanded="true"] {
+    border-color: currentColor;
+  }
+
+  .subject-menu-ready .subject-menu__trigger:focus-visible,
+  .subject-menu-ready .subject-menu__panel a:focus-visible {
+    outline: 3px solid currentColor;
+    outline-offset: 2px;
+  }
+
+  .subject-menu-ready .subject-menu__panel {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 0;
+    left: 0;
+    z-index: 300;
+    display: none;
+    max-width: 100%;
+    max-height: min(32rem, calc(100vh - 9rem));
+    overflow-x: hidden;
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    padding: 0.4rem;
+    border: 1px solid rgba(255, 255, 255, 0.22);
+    border-radius: 1rem;
+    background: #0b0c0a;
+    box-shadow: 0 1rem 3rem rgba(0, 0, 0, 0.5);
+  }
+
+  .subject-menu-ready .subject-menu__panel[aria-hidden="false"] {
+    display: grid;
+  }
+
+  .subject-menu-ready .subject-menu__panel a {
+    display: flex;
+    min-width: 0;
+    min-height: 44px;
+    align-items: center;
+    padding: 0.7rem 0.8rem;
+    border: 0;
+    border-radius: 0.65rem;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
+  .subject-menu-open .ctw-feedback-button {
+    visibility: hidden;
+    pointer-events: none;
+  }
+}

--- a/ctw.studio/signals/subject-menu.js
+++ b/ctw.studio/signals/subject-menu.js
@@ -3,10 +3,12 @@
 
   document.querySelectorAll('.atlas-topics, .topic-switcher, .evidence-topics').forEach((nav, index) => {
     const brand = nav.querySelector(':scope > .signals-home');
-    const links = [...nav.querySelectorAll(':scope > a:not(.signals-home)')];
-    if (!brand || links.length !== 10) return;
+    const options = [...nav.children].filter((option) =>
+      option.matches('a:not(.signals-home), .topic-pill--planned')
+    );
+    if (!brand || options.length !== 10) return;
 
-    const current = links.find((link) => link.getAttribute('aria-current') === 'location');
+    const current = options.find((option) => option.matches('a[aria-current="location"]'));
     const panel = document.createElement('div');
     const trigger = document.createElement('button');
     const label = document.createElement('span');
@@ -16,7 +18,7 @@
     panel.id = panelId;
     panel.className = 'subject-menu__panel';
     panel.setAttribute('aria-hidden', String(mobile.matches));
-    links.forEach((link) => panel.append(link));
+    options.forEach((option) => panel.append(option));
 
     trigger.type = 'button';
     trigger.className = 'subject-menu__trigger';

--- a/ctw.studio/signals/subject-menu.js
+++ b/ctw.studio/signals/subject-menu.js
@@ -1,0 +1,72 @@
+(() => {
+  const mobile = matchMedia('(max-width: 760px)');
+
+  document.querySelectorAll('.atlas-topics, .topic-switcher, .evidence-topics').forEach((nav, index) => {
+    const brand = nav.querySelector(':scope > .signals-home');
+    const links = [...nav.querySelectorAll(':scope > a:not(.signals-home)')];
+    if (!brand || links.length !== 10) return;
+
+    const current = links.find((link) => link.getAttribute('aria-current') === 'location');
+    const panel = document.createElement('div');
+    const trigger = document.createElement('button');
+    const label = document.createElement('span');
+    const icon = document.createElement('span');
+    const panelId = `signals-subject-panel-${index + 1}`;
+
+    panel.id = panelId;
+    panel.className = 'subject-menu__panel';
+    panel.setAttribute('aria-hidden', String(mobile.matches));
+    links.forEach((link) => panel.append(link));
+
+    trigger.type = 'button';
+    trigger.className = 'subject-menu__trigger';
+    trigger.setAttribute('aria-expanded', 'false');
+    trigger.setAttribute('aria-controls', panelId);
+    label.className = 'subject-menu__trigger-label';
+    label.textContent = current?.textContent.trim() || 'Explore subjects';
+    icon.setAttribute('aria-hidden', 'true');
+    icon.textContent = '▾';
+    trigger.append(label, icon);
+
+    nav.classList.add('subject-menu');
+    nav.append(trigger, panel);
+
+    const sizePanel = () => {
+      if (!mobile.matches) {
+        panel.style.removeProperty('max-height');
+        return;
+      }
+      panel.style.maxHeight = `${Math.max(44, innerHeight - nav.getBoundingClientRect().bottom - 24)}px`;
+    };
+
+    const close = (restoreFocus = false) => {
+      trigger.setAttribute('aria-expanded', 'false');
+      panel.setAttribute('aria-hidden', String(mobile.matches));
+      document.documentElement.classList.remove('subject-menu-open');
+      if (restoreFocus) trigger.focus();
+    };
+
+    trigger.addEventListener('click', () => {
+      const open = trigger.getAttribute('aria-expanded') !== 'true';
+      if (open) sizePanel();
+      trigger.setAttribute('aria-expanded', String(open));
+      panel.setAttribute('aria-hidden', String(!open));
+      document.documentElement.classList.toggle('subject-menu-open', open);
+    });
+    panel.addEventListener('click', (event) => {
+      if (event.target.closest('a')) close();
+    });
+    document.addEventListener('click', (event) => {
+      if (!nav.contains(event.target)) close();
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && trigger.getAttribute('aria-expanded') === 'true') close(true);
+    });
+    mobile.addEventListener('change', () => close());
+    addEventListener('resize', () => {
+      if (trigger.getAttribute('aria-expanded') === 'true') sizePanel();
+    });
+  });
+
+  document.documentElement.classList.add('subject-menu-ready');
+})();

--- a/ctw.studio/signals/tests/demography.test.mjs
+++ b/ctw.studio/signals/tests/demography.test.mjs
@@ -147,7 +147,7 @@ test('page carries substantive no-JS evidence and six accessible component table
   assert.match(html, /No demographic burden score is created/i);
   assert.match(html, /Gross immigration and gross emigration remain visible/i);
   assert.match(html, /href="\/signals\/">Signals \//);
-  assert.match(html, /href="\/signals\/#subject-demography-migration-aging" aria-current="location"/);
+  assert.match(html, /href="\/signals\/demography\/" aria-current="location"/);
 });
 
 test('renderer is dependency-free, uses baked JSON, handles missing data, and updater fails closed', () => {

--- a/ctw.studio/signals/tests/demography.test.mjs
+++ b/ctw.studio/signals/tests/demography.test.mjs
@@ -146,9 +146,8 @@ test('page carries substantive no-JS evidence and six accessible component table
   assert.match(html, /UN DESA Population Division · WPP 2024 · Medium variant/);
   assert.match(html, /No demographic burden score is created/i);
   assert.match(html, /Gross immigration and gross emigration remain visible/i);
-  for (const route of ['../ai-work/', '../food/', '../housing/', '../science/', '../healthspan/', './', '../']) {
-    assert.match(html, new RegExp(`href="${route.replace(/[./]/g, '\\$&')}"`));
-  }
+  assert.match(html, /href="\/signals\/">Signals \//);
+  assert.match(html, /href="\/signals\/#subject-demography-migration-aging" aria-current="location"/);
 });
 
 test('renderer is dependency-free, uses baked JSON, handles missing data, and updater fails closed', () => {

--- a/ctw.studio/signals/tests/education.test.mjs
+++ b/ctw.studio/signals/tests/education.test.mjs
@@ -228,10 +228,8 @@ test('page has substantive no-JS content, semantic tables, components, and navig
   ]) assert.match(html, new RegExp(phrase, 'i'));
   assert.match(html, /<noscript>/);
   assert.match(html, /No capability composite is reported/i);
-  for (const route of [
-    '../ai-work/', '../food/', '../housing/', '../science/',
-    '../healthspan/', './', '../'
-  ]) assert.match(html, new RegExp(`href="${route.replace(/[./]/g, '\\$&')}"`));
+  assert.match(html, /href="\/signals\/">Signals \//);
+  assert.match(html, /href="\/signals\/#subject-work-education-human-capability" aria-current="location"/);
   assert.match(css, /@media \(max-width: 600px\)/);
 });
 

--- a/ctw.studio/signals/tests/education.test.mjs
+++ b/ctw.studio/signals/tests/education.test.mjs
@@ -229,7 +229,7 @@ test('page has substantive no-JS content, semantic tables, components, and navig
   assert.match(html, /<noscript>/);
   assert.match(html, /No capability composite is reported/i);
   assert.match(html, /href="\/signals\/">Signals \//);
-  assert.match(html, /href="\/signals\/#subject-work-education-human-capability" aria-current="location"/);
+  assert.match(html, /href="\/signals\/ai-work\/" aria-current="location"/);
   assert.match(css, /@media \(max-width: 600px\)/);
 });
 

--- a/ctw.studio/signals/tests/financial-fragility.test.mjs
+++ b/ctw.studio/signals/tests/financial-fragility.test.mjs
@@ -149,7 +149,7 @@ test('page provides substantive no-JS evidence and every required component', ()
   assert.match(html, /One interest bill\. Two denominators\./);
   assert.match(html, /There is no financial-fragility composite or traffic-light total/);
   assert.match(html, /href="\/signals\/">Signals \//);
-  assert.match(html, /href="\/signals\/#subject-prosperity-financial-security" aria-current="location"/);
+  assert.match(html, /href="\/signals\/financial-fragility\/" aria-current="location"/);
 });
 
 test('renderer is dependency-free, defensive, and preserves accessible equivalents', () => {

--- a/ctw.studio/signals/tests/financial-fragility.test.mjs
+++ b/ctw.studio/signals/tests/financial-fragility.test.mjs
@@ -148,9 +148,8 @@ test('page provides substantive no-JS evidence and every required component', ()
   assert.match(html, /Arrears are not defaults/);
   assert.match(html, /One interest bill\. Two denominators\./);
   assert.match(html, /There is no financial-fragility composite or traffic-light total/);
-  for (const route of ['../ai-work/', '../food/', '../housing/', '../science/', '../healthspan/', './', '../']) {
-    assert.match(html, new RegExp(`href="${route.replace(/[./]/g, '\\$&')}"`));
-  }
+  assert.match(html, /href="\/signals\/">Signals \//);
+  assert.match(html, /href="\/signals\/#subject-prosperity-financial-security" aria-current="location"/);
 });
 
 test('renderer is dependency-free, defensive, and preserves accessible equivalents', () => {

--- a/ctw.studio/signals/tests/food.test.mjs
+++ b/ctw.studio/signals/tests/food.test.mjs
@@ -86,7 +86,7 @@ test('food page exposes the complete storyboard, chart alternatives, and active 
     assert.match(html, new RegExp(`id="${id}"`));
   }
   assert.match(html, /href="\/signals\/">Signals \//);
-  assert.match(html, /href="\/signals\/#subject-food-animals-planet"[^>]*aria-current="location"/);
+  assert.match(html, /href="\/signals\/food\/"[^>]*aria-current="location"/);
   assert.match(html, /food-active/);
   assert.match(html, /species-table/);
   assert.match(html, /footprint-table/);

--- a/ctw.studio/signals/tests/food.test.mjs
+++ b/ctw.studio/signals/tests/food.test.mjs
@@ -85,7 +85,8 @@ test('food page exposes the complete storyboard, chart alternatives, and active 
   for (const id of ['lives', 'climate', 'land', 'water', 'oceans', 'health', 'answer', 'sources']) {
     assert.match(html, new RegExp(`id="${id}"`));
   }
-  assert.match(html, /href="\.\.\/ai-work\/"[^>]*>AI &amp; work/);
+  assert.match(html, /href="\/signals\/">Signals \//);
+  assert.match(html, /href="\/signals\/#subject-food-animals-planet"[^>]*aria-current="location"/);
   assert.match(html, /food-active/);
   assert.match(html, /species-table/);
   assert.match(html, /footprint-table/);

--- a/ctw.studio/signals/tests/healthspan.test.mjs
+++ b/ctw.studio/signals/tests/healthspan.test.mjs
@@ -76,7 +76,7 @@ test('healthspan page exposes substantive no-JS evidence, accessible tables, and
   assert.match(html, /<noscript>/);
   assert.match(html, /prevention or treatment spending records allocation/i);
   assert.match(html, /href="\/signals\/">Signals \//);
-  assert.match(html, /href="\/signals\/#subject-healthspan-care" aria-current="location"/);
+  assert.match(html, /href="\/signals\/healthspan\/" aria-current="location"/);
 });
 
 test('health renderer and updater have no chart runtime and fail closed on schema gaps', () => {

--- a/ctw.studio/signals/tests/healthspan.test.mjs
+++ b/ctw.studio/signals/tests/healthspan.test.mjs
@@ -75,9 +75,8 @@ test('healthspan page exposes substantive no-JS evidence, accessible tables, and
   assert.match(html, /id="health-data-table"/);
   assert.match(html, /<noscript>/);
   assert.match(html, /prevention or treatment spending records allocation/i);
-  for (const route of ['../ai-work/', '../food/', '../housing/', '../science/', './', '../']) {
-    assert.match(html, new RegExp(`href="${route.replace(/[./]/g, '\\$&')}"`));
-  }
+  assert.match(html, /href="\/signals\/">Signals \//);
+  assert.match(html, /href="\/signals\/#subject-healthspan-care" aria-current="location"/);
 });
 
 test('health renderer and updater have no chart runtime and fail closed on schema gaps', () => {

--- a/ctw.studio/signals/tests/roadmap.test.mjs
+++ b/ctw.studio/signals/tests/roadmap.test.mjs
@@ -39,6 +39,10 @@ function topicPills(markup) {
     .map(([, classes, href, current, label]) => ({ classes, href, current, label }));
 }
 
+function cssRule(selector) {
+  return subjectMenuCss.match(new RegExp(`${selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\s*\\{([^}]+)\\}`))?.[1] || '';
+}
+
 function atlasCard(anchor, nextAnchor) {
   const start = html.indexOf(`<li id="${anchor}"`);
   const end = nextAnchor ? html.indexOf(`<li id="${nextAnchor}"`, start) : html.indexOf('</ol>', start);
@@ -121,6 +125,35 @@ test('all taxonomy pages load shared progressive subject disclosure assets', () 
 
   assert.match(subjectMenuCss, /@media \(max-width: 760px\)/);
   assert.match(subjectMenuCss, /\.subject-menu__panel\[aria-hidden="false"\]/);
+  assert.match(cssRule('.subject-menu-ready .subject-menu'), /--subject-menu-border:\s*rgba\(255, 255, 255, 0\.36\)/);
+  assert.match(cssRule('.subject-menu-ready .subject-menu'), /--subject-menu-accent:\s*#f7b500/);
+  assert.match(cssRule('.subject-menu-ready .subject-menu'), /--subject-menu-font:\s*Inter,\s*system-ui,\s*-apple-system,\s*BlinkMacSystemFont,\s*"Segoe UI",\s*sans-serif/);
+  for (const selector of [
+    '.subject-menu-ready .subject-menu__trigger',
+    '.subject-menu-ready .subject-menu__panel',
+    '.subject-menu-ready .subject-menu__panel a'
+  ]) {
+    const rule = cssRule(selector);
+    assert.match(rule, /font:\s*500 1rem\/1\.35 var\(--subject-menu-font\)/);
+    assert.match(rule, /color:\s*var\(--subject-menu-text\)/);
+    assert.match(rule, /letter-spacing:\s*normal/);
+    assert.match(rule, /text-transform:\s*none/);
+    if (!selector.endsWith('__panel')) assert.match(rule, /transition:\s*none/);
+    assert.doesNotMatch(rule, /(?:font|color):\s*inherit/);
+  }
+  const currentRule = cssRule('.subject-menu-ready .subject-menu__panel a[aria-current="location"]');
+  assert.match(currentRule, /background:\s*var\(--subject-menu-accent-soft\)\s*!important/);
+  assert.match(currentRule, /border-color:\s*var\(--subject-menu-accent\)\s*!important/);
+  assert.match(currentRule, /color:\s*var\(--subject-menu-accent\)\s*!important/);
+  assert.match(currentRule, /box-shadow:\s*inset [^;]*var\(--subject-menu-accent\)/);
+  const focusRule = cssRule('.subject-menu-ready .subject-menu__panel a:focus-visible');
+  assert.match(focusRule, /border-color:\s*var\(--subject-menu-accent\)/);
+  assert.match(focusRule, /color:\s*var\(--subject-menu-text\)/);
+  assert.match(focusRule, /outline:\s*3px solid var\(--subject-menu-accent\)/);
+  const hoverRule = cssRule('.subject-menu-ready .subject-menu__panel a:not([aria-current="location"]):hover');
+  assert.match(hoverRule, /background:\s*rgba\(255, 255, 255, 0\.07\)/);
+  assert.match(hoverRule, /border-color:\s*var\(--subject-menu-border\)/);
+  assert.match(hoverRule, /color:\s*var\(--subject-menu-text\)/);
   assert.match(subjectMenuJs, /createElement\('button'\)/);
   assert.match(subjectMenuJs, /setAttribute\('aria-expanded'/);
   assert.match(subjectMenuJs, /setAttribute\('aria-controls'/);

--- a/ctw.studio/signals/tests/roadmap.test.mjs
+++ b/ctw.studio/signals/tests/roadmap.test.mjs
@@ -6,110 +6,147 @@ const root = new URL('../', import.meta.url);
 const html = await readFile(new URL('index.html', root), 'utf8');
 const fallback = await readFile(new URL('roadmap/index.html', root), 'utf8');
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', root), 'utf8'));
-const briefs = [
-  ['ai-work', 'ai-work/index.html', '001', './'],
-  ['food', 'food/index.html', '002', './'],
-  ['housing', 'housing/index.html', '003', './'],
-  ['science', 'science/index.html', '004', './'],
-  ['healthspan', 'healthspan/index.html', '005', './'],
-  ['real-time-ai', 'real-time-ai/index.html', '006', './'],
-  ['demography', 'demography/index.html', '007', './'],
-  ['education', 'education/index.html', '008', './'],
-  ['financial-fragility', 'financial-fragility/index.html', '009', './']
+
+const subjects = [
+  { label: 'Housing &amp; affordability', anchor: 'subject-housing-affordability', status: 'published', briefs: [['housing', '003']] },
+  { label: 'Food, animals &amp; planet', anchor: 'subject-food-animals-planet', status: 'published', briefs: [['food', '002']] },
+  { label: 'Healthspan &amp; care', anchor: 'subject-healthspan-care', status: 'published', briefs: [['healthspan', '005']] },
+  { label: 'Work, education &amp; human capability', anchor: 'subject-work-education-human-capability', status: 'published', briefs: [['ai-work', '001'], ['education', '008']] },
+  { label: 'Prosperity &amp; financial security', anchor: 'subject-prosperity-financial-security', status: 'published', briefs: [['financial-fragility', '009']] },
+  { label: 'Energy, compute &amp; infrastructure', anchor: 'subject-energy-compute-infrastructure', status: 'planned', briefs: [] },
+  { label: 'Demography, migration &amp; aging', anchor: 'subject-demography-migration-aging', status: 'published', briefs: [['demography', '007']] },
+  { label: 'Democracy, trust &amp; information', anchor: 'subject-democracy-trust-information', status: 'planned', briefs: [] },
+  { label: 'Science, discovery &amp; AI systems', anchor: 'subject-science-discovery-ai-systems', status: 'published', briefs: [['science', '004'], ['real-time-ai', '006']] },
+  { label: 'Global resilience', anchor: 'subject-global-resilience', status: 'planned', briefs: [] }
 ];
-const briefPages = await Promise.all(briefs.map(async ([route, path, briefId, activeDestination]) => ({
-  route,
-  briefId,
-  activeDestination,
-  html: await readFile(new URL(path, root), 'utf8')
+
+const briefs = subjects.flatMap(({ anchor, briefs }) =>
+  briefs.map(([route, briefId]) => ({ route, briefId, anchor }))
+).sort((a, b) => a.briefId.localeCompare(b.briefId));
+
+const briefPages = await Promise.all(briefs.map(async (brief) => ({
+  ...brief,
+  html: await readFile(new URL(`${brief.route}/index.html`, root), 'utf8')
 })));
 
-const topics = [
-  'Housing &amp; affordability',
-  'Prosperity',
-  'Energy &amp; compute',
-  'Healthspan &amp; care',
-  'Demography, migration &amp; aging',
-  'Democracy, trust &amp; information',
-  'Science &amp; discovery',
-  'Education &amp; human capability',
-  'Financial fragility',
-  'Global resilience'
-];
+const expectedLabels = subjects.map(({ label }) => label);
+const expectedHrefs = subjects.map(({ anchor }) => `/signals/#${anchor}`);
 
-test('Atlas homepage publishes all ten subjects in the agreed order', () => {
+function topicPills(markup) {
+  return [...markup.matchAll(/<a class="([^"]*\btopic-pill\b[^"]*)" href="([^"]+)"(?: aria-current="([^"]+)")?>([^<]+)<\/a>/g)]
+    .map(([, classes, href, current, label]) => ({ classes, href, current, label }));
+}
+
+function atlasCard(anchor, nextAnchor) {
+  const start = html.indexOf(`<li id="${anchor}"`);
+  const end = nextAnchor ? html.indexOf(`<li id="${nextAnchor}"`, start) : html.indexOf('</ol>', start);
+  assert.ok(start >= 0 && end > start, `missing Atlas card ${anchor}`);
+  return html.slice(start, end);
+}
+
+test('Atlas publishes exact canonical ten-subject taxonomy and anchors', () => {
   const grid = html.match(/<ol class="atlas-grid">([\s\S]*?)<\/ol>/)?.[1] || '';
-  const cardTopics = [...grid.matchAll(/<h3>([\s\S]*?)<\/h3>/g)].map((match) => match[1]);
-  assert.deepEqual(cardTopics, topics);
+  const cards = [...grid.matchAll(/<li id="([^"]+)" class="[^"]*\batlas-card\b[^"]*" data-status="([^"]+)">[\s\S]*?<h3>([\s\S]*?)<\/h3>/g)]
+    .map(([, anchor, status, label]) => ({ anchor, status, label }));
+
+  assert.deepEqual(cards, subjects.map(({ anchor, status, label }) => ({ anchor, status, label })));
+  assert.equal(new Set(cards.map(({ anchor }) => anchor)).size, 10);
 });
 
-test('Atlas homepage states the reusable evidence contract and geographic lenses', () => {
-  for (const question of [
+test('Atlas cards expose every mapped brief separately and planned subjects honestly', () => {
+  subjects.forEach(({ anchor, status, briefs: mappings }, index) => {
+    const card = atlasCard(anchor, subjects[index + 1]?.anchor);
+    const links = [...card.matchAll(/<a href="([^"]+)">Brief ([0-9]{3}) ·/g)]
+      .map(([, href, briefId]) => [href.replace(/\/$/, ''), briefId]);
+
+    assert.deepEqual(links, mappings, `${anchor} has incorrect brief links`);
+    assert.equal(/Planned subject/.test(card), status === 'planned', `${anchor} has incorrect planned label`);
+  });
+
+  assert.equal((html.match(/data-status="published"/g) || []).length, 7);
+  assert.equal((html.match(/data-status="planned"/g) || []).length, 3);
+});
+
+test('Atlas counters and subject wording report 9 briefs, 7 covered subjects and 3 planned', () => {
+  assert.match(html, /<strong>9<\/strong>\s*published briefs/i);
+  assert.match(html, /<strong>7 of 10<\/strong>\s*subjects with published coverage/i);
+  assert.match(html, /<strong>3<\/strong>\s*subjects planned/i);
+  assert.match(html, /canonical taxonomy for ten CTW Signals subjects/);
+  assert.match(html, /Ten long-horizon subjects asking/);
+  assert.doesNotMatch(html, /Ten long-horizon briefings/);
+});
+
+test('Atlas top navigation uses brand home plus exact subject anchors', () => {
+  const nav = html.match(/<nav class="atlas-topics"[\s\S]*?<\/nav>/)?.[0] || '';
+  assert.match(nav, /<a class="signals-home atlas-brand" href="\/signals\/">Signals \/<\/a>/);
+  assert.deepEqual(
+    [...nav.matchAll(/<a href="([^"]+)">([^<]+)<\/a>/g)].map(([, href, label]) => ({ href, label })),
+    subjects.map(({ anchor, label }) => ({ href: `/signals/#${anchor}`, label }))
+  );
+  assert.doesNotMatch(nav, />Atlas<\/a>/);
+});
+
+test('every brief switcher is semantic and mirrors exact taxonomy, links and mapped current subject', () => {
+  briefPages.forEach(({ route, anchor, briefId, html: page }) => {
+    const nav = page.match(/<nav class="[^"]*(?:topic-switcher|evidence-topics)[^"]*"[\s\S]*?<\/nav>/)?.[0] || '';
+    assert.ok(nav, `${route} missing semantic topic navigation`);
+    assert.match(nav, /<a class="signals-home topic-switcher__label" href="\/signals\/">/);
+
+    const pills = topicPills(nav);
+    assert.deepEqual(pills.map(({ label }) => label), expectedLabels, `${route} subject order differs`);
+    assert.deepEqual(pills.map(({ href }) => href), expectedHrefs, `${route} subject links differ`);
+
+    const current = pills.filter(({ classes, current }) =>
+      classes.split(/\s+/).includes('topic-pill--active') || current
+    );
+    assert.equal(current.length, 1, `${route} must have one mapped current subject`);
+    assert.equal(current[0].href, `/signals/#${anchor}`, `${route} maps to wrong subject`);
+    assert.equal(current[0].current, 'location', `${route} must use aria-current="location"`);
+    assert.match(page, new RegExp(`Brief ${briefId}\\b`), `${route} missing Brief ${briefId}`);
+  });
+});
+
+test('first wave uses canonical vocabulary and truthful coverage state', () => {
+  const section = html.match(/<section class="publication-path"[\s\S]*?<\/section>/)?.[0] || '';
+  for (const label of [
+    subjects[0].label,
+    subjects[4].label,
+    subjects[5].label,
+    subjects[2].label,
+    subjects[6].label,
+    subjects[8].label
+  ]) {
+    assert.match(section, new RegExp(label));
+  }
+  assert.match(section, /Coverage is a foundation, not completion/);
+  assert.doesNotMatch(section, /<small>Next<\/small>|Prosperity[^<]*Next/i);
+});
+
+test('published foundations preserve Briefs 001–009 and existing URLs', () => {
+  const foundations = html.match(/<section class="published-foundations"[\s\S]*?<\/section>/)?.[0] || '';
+  for (const { route, briefId } of briefs) {
+    assert.match(foundations, new RegExp(`<a href="${route}/"><span>Brief ${briefId}</span>`));
+  }
+  assert.deepEqual(briefs.map(({ briefId }) => briefId), Array.from({ length: 9 }, (_, index) => String(index + 1).padStart(3, '0')));
+});
+
+test('Atlas evidence contract and geographic lenses remain intact', () => {
+  for (const text of [
     'Where are we now?',
     'What direction are we moving?',
     'Who is benefiting or carrying the cost?',
     'What are the competing explanations?',
-    'What evidence would change our current conclusion?'
+    'What evidence would change our current conclusion?',
+    'World',
+    'Europe / Netherlands',
+    'Selected countries',
+    'What might this make possible?'
   ]) {
-    assert.match(html, new RegExp(question.replace(/[?]/g, '\\?')));
-  }
-  for (const lens of ['World', 'Europe / Netherlands', 'Selected countries']) {
-    assert.match(html, new RegExp(lens));
-  }
-  assert.match(html, /What might this make possible\?/);
-});
-
-test('Atlas links all six atlas briefs and labels publication status honestly', () => {
-  for (const route of ['housing', 'healthspan', 'demography', 'science', 'education', 'financial-fragility']) {
-    assert.match(html, new RegExp(`href="${route}/"`));
-  }
-  for (const [route, card, id] of [
-    ['demography', '05', '007'],
-    ['education', '08', '008'],
-    ['financial-fragility', '09', '009']
-  ]) {
-    assert.match(html, new RegExp(`href="${route}/"[\\s\\S]*?<span>${card}</span><small>Published · Brief ${id}</small>`));
-  }
-  assert.equal((html.match(/data-status="published"/g) || []).length, 6);
-  assert.equal((html.match(/data-status="planned"/g) || []).length, 4);
-  assert.match(html, /<strong>9<\/strong>\s*briefings published/i);
-  assert.match(html, /<strong>6 of 10<\/strong>\s*atlas briefs published/i);
-  assert.match(html, /<strong>4<\/strong>\s*atlas briefs planned/i);
-});
-
-test('the preferred six-topic order is explicitly a first wave, not the complete atlas', () => {
-  assert.match(html, /Preferred first publication wave/i);
-  assert.match(html, /six-topic sequence/i);
-  assert.match(html, /complete atlas is not yet published/i);
-  for (const planned of ['Prosperity', 'Energy', 'Democracy', 'Global resilience']) {
-    assert.match(html, new RegExp(planned));
-  }
-  assert.match(html, /<strong>Healthspan<\/strong><small>Published<\/small>/);
-  assert.match(html, /<strong>Demography<\/strong><small>Published<\/small>/);
-  assert.match(html, /<strong>Science<\/strong><small>Published<\/small>/);
-});
-
-test('atlas and published foundations expose Briefs 001–009 plus Atlas navigation', () => {
-  for (const label of [
-    'AI &amp; work',
-    'Food &amp; planet',
-    'Housing',
-    'Science',
-    'Healthspan',
-    'Real-time AI',
-    'Demography',
-    'Education',
-    'Financial fragility',
-    'Atlas'
-  ]) {
-    assert.match(html, new RegExp(label));
-  }
-  for (const number of Array.from({ length: 9 }, (_, index) => String(index + 1).padStart(3, '0'))) {
-    assert.match(html, new RegExp(`Brief ${number}`));
+    assert.match(html, new RegExp(text.replace(/[?]/g, '\\?')));
   }
 });
 
-test('Atlas is first post-hero section and old roadmap routes redirect exactly', () => {
+test('Atlas remains homepage and legacy roadmap redirects remain exact', () => {
   assert.ok(html.indexOf('atlas-topics-section') < html.indexOf('atlas-standard'));
   assert.match(fallback, /name="robots" content="noindex,follow"/);
   assert.match(fallback, /rel="canonical" href="https:\/\/ctw\.studio\/signals\/"/);
@@ -125,49 +162,4 @@ test('NLeSC legacy home routes redirect exactly', () => {
     { source: '/nlesc/home', destination: '/nlesc/', permanent: true },
     { source: '/nlesc/home/', destination: '/nlesc/', permanent: true }
   ]);
-});
-
-test('every published brief switcher exposes ten destinations in canonical order', () => {
-  const labels = [
-    'AI &amp; work',
-    'Food',
-    'Housing',
-    'Science',
-    'Healthspan',
-    'Real-time AI',
-    'Demography',
-    'Education',
-    'Financial fragility',
-    'Atlas'
-  ];
-  const routes = briefs.map(([route]) => route);
-
-  briefPages.forEach(({ route, briefId, activeDestination, html: page }) => {
-    const start = page.search(/class="[^"]*(?:topic-switcher|evidence-topics)[^"]*"/);
-    assert.ok(start >= 0, `${route} missing topic switcher`);
-    const switcher = page.slice(start, start + 3000);
-    let cursor = -1;
-    labels.forEach((label) => {
-      const next = switcher.indexOf(label);
-      assert.ok(next > cursor, `${route} missing or reorders ${label}`);
-      cursor = next;
-    });
-    const pills = [...switcher.matchAll(/<a\b([^>]*)class="([^"]*\btopic-pill\b[^"]*)"([^>]*)>/g)]
-      .slice(0, 10);
-    const hrefs = pills.map((match) => `${match[1]}${match[3]}`.match(/href="([^"]+)"/)?.[1]);
-    const expected = routes.map((destination) => destination === route ? './' : `../${destination}/`);
-    expected.push('../');
-    assert.deepEqual(hrefs, expected, `${route} has incorrect switcher routes`);
-    const activePills = pills.filter((match) =>
-      /(?:^|\s)\S*active(?:\s|$)/.test(match[2]) ||
-      /aria-current="page"/.test(`${match[1]}${match[3]}`)
-    );
-    assert.equal(activePills.length, 1, `${route} must have exactly one active/current topic pill`);
-    assert.equal(
-      `${activePills[0][1]}${activePills[0][3]}`.match(/href="([^"]+)"/)?.[1],
-      activeDestination,
-      `${route} active/current topic pill must link to itself`
-    );
-    assert.match(page, new RegExp(`Brief ${briefId}\\b`), `${route} missing Brief ${briefId}`);
-  });
 });

--- a/ctw.studio/signals/tests/roadmap.test.mjs
+++ b/ctw.studio/signals/tests/roadmap.test.mjs
@@ -6,24 +6,25 @@ const root = new URL('../', import.meta.url);
 const html = await readFile(new URL('index.html', root), 'utf8');
 const fallback = await readFile(new URL('roadmap/index.html', root), 'utf8');
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', root), 'utf8'));
+const atlasCss = await readFile(new URL('atlas.css', root), 'utf8');
 const subjectMenuCss = await readFile(new URL('subject-menu.css', root), 'utf8');
 const subjectMenuJs = await readFile(new URL('subject-menu.js', root), 'utf8');
 
 const subjects = [
-  { label: 'Housing &amp; affordability', anchor: 'subject-housing-affordability', status: 'published', briefs: [['housing', '003']] },
-  { label: 'Food, animals &amp; planet', anchor: 'subject-food-animals-planet', status: 'published', briefs: [['food', '002']] },
-  { label: 'Healthspan &amp; care', anchor: 'subject-healthspan-care', status: 'published', briefs: [['healthspan', '005']] },
-  { label: 'Work, education &amp; human capability', anchor: 'subject-work-education-human-capability', status: 'published', briefs: [['ai-work', '001'], ['education', '008']] },
-  { label: 'Prosperity &amp; financial security', anchor: 'subject-prosperity-financial-security', status: 'published', briefs: [['financial-fragility', '009']] },
-  { label: 'Energy, compute &amp; infrastructure', anchor: 'subject-energy-compute-infrastructure', status: 'planned', briefs: [] },
-  { label: 'Demography, migration &amp; aging', anchor: 'subject-demography-migration-aging', status: 'published', briefs: [['demography', '007']] },
-  { label: 'Democracy, trust &amp; information', anchor: 'subject-democracy-trust-information', status: 'planned', briefs: [] },
-  { label: 'Science, discovery &amp; AI systems', anchor: 'subject-science-discovery-ai-systems', status: 'published', briefs: [['science', '004'], ['real-time-ai', '006']] },
-  { label: 'Global resilience', anchor: 'subject-global-resilience', status: 'planned', briefs: [] }
+  { label: 'Housing &amp; affordability', anchor: 'subject-housing-affordability', route: '/signals/housing/', status: 'published', briefs: [['housing', '003']] },
+  { label: 'Food, animals &amp; planet', anchor: 'subject-food-animals-planet', route: '/signals/food/', status: 'published', briefs: [['food', '002']] },
+  { label: 'Healthspan &amp; care', anchor: 'subject-healthspan-care', route: '/signals/healthspan/', status: 'published', briefs: [['healthspan', '005']] },
+  { label: 'Work, education &amp; human capability', anchor: 'subject-work-education-human-capability', route: '/signals/ai-work/', status: 'published', briefs: [['ai-work', '001'], ['education', '008']] },
+  { label: 'Prosperity &amp; financial security', anchor: 'subject-prosperity-financial-security', route: '/signals/financial-fragility/', status: 'published', briefs: [['financial-fragility', '009']] },
+  { label: 'Energy, compute &amp; infrastructure', anchor: 'subject-energy-compute-infrastructure', route: null, status: 'planned', briefs: [] },
+  { label: 'Demography, migration &amp; aging', anchor: 'subject-demography-migration-aging', route: '/signals/demography/', status: 'published', briefs: [['demography', '007']] },
+  { label: 'Democracy, trust &amp; information', anchor: 'subject-democracy-trust-information', route: null, status: 'planned', briefs: [] },
+  { label: 'Science, discovery &amp; AI systems', anchor: 'subject-science-discovery-ai-systems', route: '/signals/science/', status: 'published', briefs: [['science', '004'], ['real-time-ai', '006']] },
+  { label: 'Global resilience', anchor: 'subject-global-resilience', route: null, status: 'planned', briefs: [] }
 ];
 
-const briefs = subjects.flatMap(({ anchor, briefs }) =>
-  briefs.map(([route, briefId]) => ({ route, briefId, anchor }))
+const briefs = subjects.flatMap(({ route: subjectRoute, briefs }) =>
+  briefs.map(([route, briefId]) => ({ route, briefId, subjectRoute }))
 ).sort((a, b) => a.briefId.localeCompare(b.briefId));
 
 const briefPages = await Promise.all(briefs.map(async (brief) => ({
@@ -32,11 +33,25 @@ const briefPages = await Promise.all(briefs.map(async (brief) => ({
 })));
 
 const expectedLabels = subjects.map(({ label }) => label);
-const expectedHrefs = subjects.map(({ anchor }) => `/signals/#${anchor}`);
+const expectedRoutes = subjects.map(({ route }) => route);
 
-function topicPills(markup) {
-  return [...markup.matchAll(/<a class="([^"]*\btopic-pill\b[^"]*)" href="([^"]+)"(?: aria-current="([^"]+)")?>([^<]+)<\/a>/g)]
-    .map(([, classes, href, current, label]) => ({ classes, href, current, label }));
+function subjectOptions(markup) {
+  const options = [];
+  const pattern = /<a(?: class="([^"]*)")? href="([^"]+)"(?: aria-current="([^"]+)")?>([^<]+)<\/a>|<span class="([^"]*\btopic-pill--planned\b[^"]*)">([^<]+) <span class="topic-pill__badge">Planned<\/span><\/span>/g;
+
+  for (const match of markup.matchAll(pattern)) {
+    const [, classes = '', href, current, linkLabel, plannedClasses, plannedLabel] = match;
+    if (classes.split(/\s+/).includes('signals-home')) continue;
+    options.push({
+      classes: href ? classes : plannedClasses,
+      current,
+      label: href ? linkLabel : plannedLabel,
+      route: href || null,
+      tag: href ? 'a' : 'span',
+      markup: match[0]
+    });
+  }
+  return options;
 }
 
 function cssRule(selector) {
@@ -82,34 +97,54 @@ test('Atlas counters and subject wording report 9 briefs, 7 covered subjects and
   assert.doesNotMatch(html, /Ten long-horizon briefings/);
 });
 
-test('Atlas top navigation uses brand home plus exact subject anchors', () => {
+test('Atlas top navigation uses exact canonical routes and native planned rows', () => {
   const nav = html.match(/<nav class="atlas-topics"[\s\S]*?<\/nav>/)?.[0] || '';
   assert.match(nav, /<a class="signals-home atlas-brand" href="\/signals\/">Signals \/<\/a>/);
-  assert.deepEqual(
-    [...nav.matchAll(/<a href="([^"]+)">([^<]+)<\/a>/g)].map(([, href, label]) => ({ href, label })),
-    subjects.map(({ anchor, label }) => ({ href: `/signals/#${anchor}`, label }))
-  );
+  const options = subjectOptions(nav);
+  assert.deepEqual(options.map(({ label }) => label), expectedLabels);
+  assert.deepEqual(options.map(({ route }) => route), expectedRoutes);
+  assert.equal(options.filter(({ tag }) => tag === 'a').length, 7);
+  assert.equal(options.filter(({ tag }) => tag === 'span').length, 3);
+  assert.equal(options.filter(({ current }) => current).length, 0);
   assert.doesNotMatch(nav, />Atlas<\/a>/);
 });
 
-test('every brief switcher is semantic and mirrors exact taxonomy, links and mapped current subject', () => {
-  briefPages.forEach(({ route, anchor, briefId, html: page }) => {
+test('every brief switcher mirrors exact routes, planned rows and mapped current subject', () => {
+  briefPages.forEach(({ route, subjectRoute, briefId, html: page }) => {
     const nav = page.match(/<nav class="[^"]*(?:topic-switcher|evidence-topics)[^"]*"[\s\S]*?<\/nav>/)?.[0] || '';
     assert.ok(nav, `${route} missing semantic topic navigation`);
     assert.match(nav, /<a class="signals-home topic-switcher__label" href="\/signals\/">/);
 
-    const pills = topicPills(nav);
-    assert.deepEqual(pills.map(({ label }) => label), expectedLabels, `${route} subject order differs`);
-    assert.deepEqual(pills.map(({ href }) => href), expectedHrefs, `${route} subject links differ`);
+    const options = subjectOptions(nav);
+    assert.deepEqual(options.map(({ label }) => label), expectedLabels, `${route} subject order differs`);
+    assert.deepEqual(options.map(({ route }) => route), expectedRoutes, `${route} subject routes differ`);
+    assert.equal(options.filter(({ tag }) => tag === 'a').length, 7, `${route} must have seven subject links`);
+    assert.equal(options.filter(({ tag }) => tag === 'span').length, 3, `${route} must have three planned rows`);
 
-    const current = pills.filter(({ classes, current }) =>
+    const current = options.filter(({ classes, current }) =>
       classes.split(/\s+/).includes('topic-pill--active') || current
     );
     assert.equal(current.length, 1, `${route} must have one mapped current subject`);
-    assert.equal(current[0].href, `/signals/#${anchor}`, `${route} maps to wrong subject`);
+    assert.equal(current[0].tag, 'a', `${route} current subject must be a link`);
+    assert.equal(current[0].route, subjectRoute, `${route} maps to wrong subject`);
     assert.equal(current[0].current, 'location', `${route} must use aria-current="location"`);
     assert.match(page, new RegExp(`Brief ${briefId}\\b`), `${route} missing Brief ${briefId}`);
   });
+});
+
+test('planned subject rows stay visibly native and noninteractive on every navigation copy', () => {
+  for (const { route, html: page } of [{ route: 'atlas', html }, ...briefPages]) {
+    const nav = page.match(/<nav class="[^"]*(?:atlas-topics|topic-switcher|evidence-topics)[^"]*"[\s\S]*?<\/nav>/)?.[0] || '';
+    const planned = subjectOptions(nav).filter(({ tag }) => tag === 'span');
+
+    assert.equal(planned.length, 3, `${route} planned-row count differs`);
+    for (const option of planned) {
+      assert.match(option.markup, /<span class="topic-pill__badge">Planned<\/span>/);
+      assert.doesNotMatch(option.markup, /\b(?:href|role|tabindex|onclick|aria-disabled)=/i);
+    }
+  }
+  assert.match(atlasCss, /\.atlas-topics \.topic-pill--planned\s*\{[^}]*color:\s*var\(--atlas-muted\)/s);
+  assert.match(atlasCss, /\.atlas-topics \.topic-pill__badge\s*\{[^}]*color:\s*var\(--atlas-muted\)/s);
 });
 
 test('all taxonomy pages load shared progressive subject disclosure assets', () => {
@@ -131,7 +166,7 @@ test('all taxonomy pages load shared progressive subject disclosure assets', () 
   for (const selector of [
     '.subject-menu-ready .subject-menu__trigger',
     '.subject-menu-ready .subject-menu__panel',
-    '.subject-menu-ready .subject-menu__panel a'
+    '.subject-menu-ready .subject-menu__panel > :is(a, .topic-pill--planned)'
   ]) {
     const rule = cssRule(selector);
     assert.match(rule, /font:\s*500 1rem\/1\.35 var\(--subject-menu-font\)/);
@@ -154,11 +189,20 @@ test('all taxonomy pages load shared progressive subject disclosure assets', () 
   assert.match(hoverRule, /background:\s*rgba\(255, 255, 255, 0\.07\)/);
   assert.match(hoverRule, /border-color:\s*var\(--subject-menu-border\)/);
   assert.match(hoverRule, /color:\s*var\(--subject-menu-text\)/);
+  const plannedRule = cssRule('.subject-menu-ready .subject-menu__panel > .topic-pill--planned');
+  assert.match(plannedRule, /color:\s*color-mix\(in srgb, var\(--subject-menu-text\) 65%, transparent\)/);
+  assert.match(plannedRule, /cursor:\s*default/);
+  assert.match(cssRule('.topic-pill--planned'), /opacity:\s*1/);
+  assert.match(cssRule('.topic-pill--planned'), /pointer-events:\s*none/);
   assert.match(subjectMenuJs, /createElement\('button'\)/);
   assert.match(subjectMenuJs, /setAttribute\('aria-expanded'/);
   assert.match(subjectMenuJs, /setAttribute\('aria-controls'/);
-  assert.match(subjectMenuJs, /getAttribute\('aria-current'\) === 'location'/);
+  assert.match(subjectMenuJs, /option\.matches\('a:not\(\.signals-home\), \.topic-pill--planned'\)/);
+  assert.match(subjectMenuJs, /options\.length !== 10/);
+  assert.match(subjectMenuJs, /option\.matches\('a\[aria-current="location"\]'\)/);
+  assert.match(subjectMenuJs, /options\.forEach\(\(option\) => panel\.append\(option\)\)/);
   assert.match(subjectMenuJs, /\|\| 'Explore subjects'/);
+  assert.match(subjectMenuJs, /event\.target\.closest\('a'\)/);
   assert.match(subjectMenuJs, /event\.key === 'Escape'/);
 });
 

--- a/ctw.studio/signals/tests/roadmap.test.mjs
+++ b/ctw.studio/signals/tests/roadmap.test.mjs
@@ -6,6 +6,8 @@ const root = new URL('../', import.meta.url);
 const html = await readFile(new URL('index.html', root), 'utf8');
 const fallback = await readFile(new URL('roadmap/index.html', root), 'utf8');
 const vercel = JSON.parse(await readFile(new URL('../vercel.json', root), 'utf8'));
+const subjectMenuCss = await readFile(new URL('subject-menu.css', root), 'utf8');
+const subjectMenuJs = await readFile(new URL('subject-menu.js', root), 'utf8');
 
 const subjects = [
   { label: 'Housing &amp; affordability', anchor: 'subject-housing-affordability', status: 'published', briefs: [['housing', '003']] },
@@ -104,6 +106,27 @@ test('every brief switcher is semantic and mirrors exact taxonomy, links and map
     assert.equal(current[0].current, 'location', `${route} must use aria-current="location"`);
     assert.match(page, new RegExp(`Brief ${briefId}\\b`), `${route} missing Brief ${briefId}`);
   });
+});
+
+test('all taxonomy pages load shared progressive subject disclosure assets', () => {
+  const pages = [{ route: 'atlas', html }, ...briefPages];
+
+  pages.forEach(({ route, html: page }) => {
+    const stylesheets = [...page.matchAll(/<link\b[^>]*\brel="stylesheet"[^>]*\bhref="([^"]+)"[^>]*>|<link\b[^>]*\bhref="([^"]+)"[^>]*\brel="stylesheet"[^>]*>/g)]
+      .map((match) => match[1] || match[2])
+      .filter((href) => /\.css(?:\?|$)/.test(href));
+    assert.match(stylesheets.at(-1), /subject-menu\.css$/, `${route} must load subject menu CSS after page CSS`);
+    assert.match(page, /<script defer src="(?:\.\.\/)?subject-menu\.js"><\/script>/, `${route} missing deferred subject menu script`);
+  });
+
+  assert.match(subjectMenuCss, /@media \(max-width: 760px\)/);
+  assert.match(subjectMenuCss, /\.subject-menu__panel\[aria-hidden="false"\]/);
+  assert.match(subjectMenuJs, /createElement\('button'\)/);
+  assert.match(subjectMenuJs, /setAttribute\('aria-expanded'/);
+  assert.match(subjectMenuJs, /setAttribute\('aria-controls'/);
+  assert.match(subjectMenuJs, /getAttribute\('aria-current'\) === 'location'/);
+  assert.match(subjectMenuJs, /\|\| 'Explore subjects'/);
+  assert.match(subjectMenuJs, /event\.key === 'Escape'/);
 });
 
 test('first wave uses canonical vocabulary and truthful coverage state', () => {

--- a/ctw.studio/signals/tests/science.test.mjs
+++ b/ctw.studio/signals/tests/science.test.mjs
@@ -70,7 +70,7 @@ test('science page contains substantive no-JS evidence, tables, sources, and com
   assert.match(html, /<noscript>/);
   assert.match(html, /Publication volume is not meaningful discovery/i);
   assert.match(html, /href="\/signals\/">Signals \//);
-  assert.match(html, /href="\/signals\/#subject-science-discovery-ai-systems" aria-current="location"/);
+  assert.match(html, /href="\/signals\/science\/" aria-current="location"/);
 });
 
 test('science renderer and updater are dependency-free and fail closed', () => {

--- a/ctw.studio/signals/tests/science.test.mjs
+++ b/ctw.studio/signals/tests/science.test.mjs
@@ -69,9 +69,8 @@ test('science page contains substantive no-JS evidence, tables, sources, and com
   assert.match(html, /id="science-data-table"/);
   assert.match(html, /<noscript>/);
   assert.match(html, /Publication volume is not meaningful discovery/i);
-  for (const route of ['../ai-work/', '../food/', '../housing/', './', '../healthspan/', '../']) {
-    assert.match(html, new RegExp(`href="${route.replace(/[./]/g, '\\$&')}"`));
-  }
+  assert.match(html, /href="\/signals\/">Signals \//);
+  assert.match(html, /href="\/signals\/#subject-science-discovery-ai-systems" aria-current="location"/);
 });
 
 test('science renderer and updater are dependency-free and fail closed', () => {


### PR DESCRIPTION
## Summary
- make the approved ten-subject Atlas taxonomy canonical across the Signals homepage and all nine briefs
- map existing briefs beneath seven covered subjects while keeping three subjects visibly planned
- replace the oversized mobile pill wall with an accessible compact subject disclosure while preserving the desktop taxonomy and no-JS links
- align counters, card anchors, tests, and Signals documentation

## Verification
- `node --test signals/tests/*.test.mjs` — 103/103 passed
- all ten Signals JavaScript files passed `node --check`
- `python3 -m py_compile signals/scripts/*.py` — passed
- local-link audit checked 10 HTML pages — all links resolved
- headless Chrome checked all ten routes at 390×844, five theme families at 320×568, desktop reset at 1280px, and no-JS fallback
- verified exact trigger/current labels, ten-link order, toggle/outside/Escape behavior, Escape focus restoration, short-viewport scrolling, zero horizontal overflow, and zero runtime/log errors
- visually inspected closed/open Food plus narrow Financial Fragility; fixed Feedback overlap while the dropdown is open
- `git diff --check` — passed
- final fresh read-only Codex review — CLEAN

## Notes
- no Floating UI or third-party dependency was added; simple local CSS/JS is sufficient for this fixed anchor geometry
- no evidence data, updater behavior, routes, or deployment configuration changed
- existing Briefs 001–009 keep their URLs and content
- unrelated NLeSC preview status is outside this change
