### PR TITLE
Unify Signals desktop subject navigation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,7 @@ Use targeted checks while editing. Before handoff, run applicable app checks, se
 ## Signals evidence architecture
 
 - Browser code reads committed JSON only. Never add visitor-time evidence API calls or a chart runtime for Signals.
+- `subject-menu.css` owns all `.subject-menu` internals; page styles may only use the retained placement class for outer spacing.
 - Updaters own stable official no-key series and validate schema, definitions, units, geography, and chronology before writing.
 - Papers, forecasts, experiments, interpretations, and non-API evidence stay manually curated and source-auditable.
 - Real-time AI regulatory scope, benchmarks, field evidence, and maturity flags stay manually curated; no source automatically sets a maturity verdict.

--- a/ctw.studio/signals/README.md
+++ b/ctw.studio/signals/README.md
@@ -34,7 +34,9 @@ Atlas order, coverage and brief mapping:
 
 Current state: **9 published briefs**, **7 of 10 subjects with published coverage**, **3 planned subjects**. Coverage is not a completeness claim. Atlas and brief-page subject navigation uses seven canonical brief routes plus three visibly planned noninteractive rows; each brief marks its mapped subject with `aria-current="location"`. The Signals brand links to `/signals/`.
 
-At 760px and below, `subject-menu.js` progressively enhances that same semantic navigation into a compact accessible disclosure. Without JavaScript, seven canonical links and three visibly planned noninteractive rows remain visible.
+Every copy follows one static component contract: `.subject-menu` plus one placement class (`.atlas-topics`, `.topic-switcher`, `.evidence-topics`, `.housing-topics` or `.fragility-topics`), one `.subject-menu__brand`, and exactly ten `.subject-menu__option` children. Planned spans also use `.subject-menu__option--planned` with a `.subject-menu__badge`; `aria-current="location"` alone marks the mapped current subject.
+
+`subject-menu.css` owns component layout, typography, states, options, badges, trigger, panel and responsive behavior. Page styles may use the retained placement class only for outer spacing. At 760px and below, `subject-menu.js` idempotently moves the ten options into a compact accessible disclosure. Without JavaScript, the static menu remains visible with seven canonical links and three noninteractive planned rows.
 
 ## Files
 

--- a/ctw.studio/signals/ai-work/index.html
+++ b/ctw.studio/signals/ai-work/index.html
@@ -33,18 +33,18 @@
   <main id="main-content">
     <header class="signal-hero">
       <div class="signal-shell">
-        <nav class="topic-switcher" aria-label="CTW Signals subjects">
-          <a class="signals-home topic-switcher__label" href="/signals/">CTW Signals</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill topic-pill--active" href="/signals/ai-work/" aria-current="location">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu topic-switcher" aria-label="CTW Signals subjects">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/" aria-current="location">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
 
         <div class="hero-grid">

--- a/ctw.studio/signals/atlas.css
+++ b/ctw.studio/signals/atlas.css
@@ -16,15 +16,7 @@
 .roadmap-page body::before { position: fixed; inset: 0; z-index: -1; content: ""; pointer-events: none; background: radial-gradient(circle at 82% 8%, rgba(186,217,159,.08), transparent 33rem), linear-gradient(rgba(255,255,255,.015) 1px, transparent 1px), linear-gradient(90deg, rgba(255,255,255,.015) 1px, transparent 1px); background-size: auto, 52px 52px, 52px 52px; }
 .atlas-shell { width: min(1160px, calc(100% - 48px)); margin-inline: auto; }
 .atlas-hero { padding: 118px 0 90px; border-bottom: 1px solid var(--atlas-line); }
-.atlas-topics { display: flex; flex-wrap: wrap; align-items: center; gap: 7px; padding-bottom: 78px; }
-.atlas-topics a,
-.atlas-topics .topic-pill--planned { display: flex; flex: 0 0 auto; align-items: center; gap: 7px; padding: 8px 12px; border: 1px solid var(--atlas-line); border-radius: 99px; color: var(--atlas-muted); font: 500 10px/1 var(--atlas-mono); text-decoration: none; }
-.atlas-topics .topic-pill--planned { border-style: dashed; color: var(--atlas-muted); }
-.atlas-topics .topic-pill__badge { color: var(--atlas-muted); font-size: 7px; letter-spacing: .08em; text-transform: uppercase; }
-.atlas-topics .atlas-brand { margin-right: 3px; padding-left: 0; border-color: transparent; color: var(--atlas-paper); letter-spacing: .12em; text-transform: uppercase; }
-.atlas-topics a:hover,
-.atlas-topics a:focus-visible { color: var(--atlas-paper); border-color: rgba(238,238,231,.3); }
-.atlas-topics .active { color: var(--atlas-green); border-color: rgba(186,217,159,.42); background: rgba(186,217,159,.07); }
+.atlas-topics { padding-bottom: 78px; }
 .atlas-kicker,
 .section-label { margin: 0 0 22px; color: var(--atlas-green); font: 500 10px/1 var(--atlas-mono); letter-spacing: .13em; text-transform: uppercase; }
 .atlas-hero h1 { max-width: 1000px; margin: 0; font-size: clamp(53px, 8.2vw, 112px); line-height: .92; letter-spacing: -.07em; }

--- a/ctw.studio/signals/demography/index.html
+++ b/ctw.studio/signals/demography/index.html
@@ -23,18 +23,18 @@
   <main id="main-content">
     <header class="evidence-hero demography-hero">
       <div class="signal-shell">
-        <nav class="evidence-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill topic-pill--active" href="/signals/demography/" aria-current="location">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu evidence-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/" aria-current="location">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/education/index.html
+++ b/ctw.studio/signals/education/index.html
@@ -23,18 +23,18 @@
   <main id="main-content">
     <header class="evidence-hero">
       <div class="signal-shell">
-        <nav class="evidence-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill topic-pill--active" href="/signals/ai-work/" aria-current="location">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu evidence-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/" aria-current="location">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/financial-fragility/financial-fragility.css
+++ b/ctw.studio/signals/financial-fragility/financial-fragility.css
@@ -68,34 +68,7 @@
 }
 
 .fragility-topics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 7px;
-  align-items: center;
   padding: 118px 0 24px;
-  font-family: var(--ff-mono);
-  font-size: 11px;
-}
-
-.fragility-topics .topic-label {
-  margin-right: 5px;
-  color: var(--ff-muted);
-  text-transform: uppercase;
-}
-
-.fragility-topics .topic-pill {
-  padding: 6px 10px;
-  border: 1px solid var(--ff-line);
-  border-radius: 999px;
-  color: #b9bec8;
-  text-decoration: none;
-}
-
-.fragility-topics .topic-pill:hover,
-.fragility-topics .topic-pill:focus-visible,
-.fragility-topics .fragility-active {
-  border-color: var(--ff-acid);
-  color: var(--ff-acid);
 }
 
 .fragility-hero-grid {
@@ -1076,14 +1049,7 @@
   }
 
   .fragility-topics {
-    overflow-x: visible;
-    flex-wrap: wrap;
     padding-bottom: 12px;
-  }
-
-  .fragility-topics .topic-pill,
-  .fragility-topics .topic-label {
-    flex: 0 0 auto;
   }
 
   .fragility-hero-grid {

--- a/ctw.studio/signals/financial-fragility/index.html
+++ b/ctw.studio/signals/financial-fragility/index.html
@@ -24,18 +24,18 @@
   <main id="main-content">
     <header class="fragility-hero" aria-labelledby="page-title">
       <div class="signal-shell">
-        <nav class="topic-switcher fragility-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill topic-pill--active fragility-active" href="/signals/financial-fragility/" aria-current="location">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu fragility-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/" aria-current="location">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
 
         <div class="fragility-hero-grid">

--- a/ctw.studio/signals/food/food.css
+++ b/ctw.studio/signals/food/food.css
@@ -11,25 +11,6 @@
   --radius-lg: 1.35rem;
 }
 
-/* Brief 002 shares the system tokens with Brief 001, but uses a more editorial
-   chapter vocabulary. These structural rules intentionally stay local. */
-.food-page .topic-pill {
-  color: inherit;
-  text-decoration: none;
-}
-
-.food-page .topic-label {
-  margin-right: 0.7rem;
-  color: var(--ink);
-  font-weight: 500;
-}
-
-.food-page .topic-pill.future small {
-  margin-left: 0.35rem;
-  color: var(--ink-soft);
-  font-size: inherit;
-}
-
 .brief-id {
   display: flex;
   max-width: 41rem;
@@ -480,12 +461,6 @@
 .food-page .chapter-kicker,
 .food-page .chart-eyebrow {
   color: var(--food);
-}
-
-.food-active {
-  border-color: var(--food) !important;
-  background: var(--food-soft) !important;
-  color: var(--food) !important;
 }
 
 .food-dot {
@@ -1246,9 +1221,6 @@
 }
 
 @media (max-width: 760px) {
-  .food-page .topic-switcher { align-items: flex-start; }
-  .food-page .topic-label { width: 100%; margin-bottom: 0.2rem; }
-  .food-page .topic-pill.future { display: none; }
   .food-page .future-card { grid-template-columns: 1fr; }
   .food-page .signal-footer > .signal-shell { align-items: flex-start; flex-direction: column; }
 }

--- a/ctw.studio/signals/food/index.html
+++ b/ctw.studio/signals/food/index.html
@@ -34,18 +34,18 @@
   <main id="main-content">
     <section class="signal-hero food-hero" aria-labelledby="page-title">
       <div class="signal-shell">
-        <nav class="topic-switcher" aria-label="Signal subjects">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill topic-pill--active active food-active" href="/signals/food/" aria-current="location">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu topic-switcher" aria-label="Signal subjects">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/" aria-current="location">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
 
         <div class="hero-grid">

--- a/ctw.studio/signals/healthspan/index.html
+++ b/ctw.studio/signals/healthspan/index.html
@@ -23,18 +23,18 @@
   <main id="main-content">
     <header class="evidence-hero">
       <div class="signal-shell">
-        <nav class="evidence-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill topic-pill--active" href="/signals/healthspan/" aria-current="location">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu evidence-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/" aria-current="location">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/housing/housing.css
+++ b/ctw.studio/signals/housing/housing.css
@@ -71,44 +71,7 @@
 }
 
 .housing-topics {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 7px;
-  overflow-x: visible;
   padding: 3px 0 52px;
-}
-
-.housing-topics .topic-label {
-  flex: 0 0 auto;
-  margin-right: 4px;
-  color: var(--housing-faint);
-  font: 500 11px/1 var(--housing-mono);
-  letter-spacing: .12em;
-  text-transform: uppercase;
-}
-
-.housing-topics .topic-pill {
-  flex: 0 0 auto;
-  padding: 8px 12px;
-  border: 1px solid var(--housing-line);
-  border-radius: 999px;
-  color: var(--housing-muted);
-  font: 500 11px/1 var(--housing-mono);
-  text-decoration: none;
-  transition: border-color .2s ease, color .2s ease, background .2s ease;
-}
-
-.housing-topics .topic-pill:hover,
-.housing-topics .topic-pill:focus-visible {
-  border-color: var(--housing-line-strong);
-  color: var(--housing-paper);
-}
-
-.housing-topics .housing-active {
-  border-color: rgba(255, 177, 92, .5);
-  background: rgba(255, 177, 92, .11);
-  color: var(--housing-gold);
 }
 
 .housing-hero-grid {

--- a/ctw.studio/signals/housing/index.html
+++ b/ctw.studio/signals/housing/index.html
@@ -24,18 +24,18 @@
   <main id="main-content">
     <header class="housing-hero" aria-labelledby="page-title">
       <div class="signal-shell">
-        <nav class="topic-switcher housing-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill topic-pill--active housing-active" href="/signals/housing/" aria-current="location">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu housing-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/" aria-current="location">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
 
         <div class="housing-hero-grid">

--- a/ctw.studio/signals/index.html
+++ b/ctw.studio/signals/index.html
@@ -27,18 +27,18 @@
   <main id="main-content">
     <header class="atlas-hero">
       <div class="atlas-shell">
-        <nav class="atlas-topics" aria-label="Signal subjects">
-          <a class="signals-home atlas-brand" href="/signals/">Signals /</a>
-          <a href="/signals/housing/">Housing &amp; affordability</a>
-          <a href="/signals/food/">Food, animals &amp; planet</a>
-          <a href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a href="/signals/science/">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu atlas-topics" aria-label="Signal subjects">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
         <p class="atlas-kicker">The Signals atlas · Version 1</p>
         <h1>Important questions,<br><em>held to one standard.</em></h1>

--- a/ctw.studio/signals/real-time-ai/index.html
+++ b/ctw.studio/signals/real-time-ai/index.html
@@ -24,18 +24,18 @@
   <main id="main-content">
     <header class="evidence-hero realtime-hero">
       <div class="signal-shell">
-        <nav class="evidence-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill topic-pill--active" href="/signals/science/" aria-current="location">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu evidence-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/" aria-current="location">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/science/index.html
+++ b/ctw.studio/signals/science/index.html
@@ -23,18 +23,18 @@
   <main id="main-content">
     <header class="evidence-hero">
       <div class="signal-shell">
-        <nav class="evidence-topics" aria-label="Signal topics">
-          <a class="signals-home topic-switcher__label" href="/signals/">Signals /</a>
-          <a class="topic-pill" href="/signals/housing/">Housing &amp; affordability</a>
-          <a class="topic-pill" href="/signals/food/">Food, animals &amp; planet</a>
-          <a class="topic-pill" href="/signals/healthspan/">Healthspan &amp; care</a>
-          <a class="topic-pill" href="/signals/ai-work/">Work, education &amp; human capability</a>
-          <a class="topic-pill" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
-          <span class="topic-pill topic-pill--planned">Energy, compute &amp; infrastructure <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill" href="/signals/demography/">Demography, migration &amp; aging</a>
-          <span class="topic-pill topic-pill--planned">Democracy, trust &amp; information <span class="topic-pill__badge">Planned</span></span>
-          <a class="topic-pill topic-pill--active" href="/signals/science/" aria-current="location">Science, discovery &amp; AI systems</a>
-          <span class="topic-pill topic-pill--planned">Global resilience <span class="topic-pill__badge">Planned</span></span>
+        <nav class="subject-menu evidence-topics" aria-label="Signal topics">
+          <a class="subject-menu__brand" href="/signals/">Signals /</a>
+          <a class="subject-menu__option" href="/signals/housing/">Housing &amp; affordability</a>
+          <a class="subject-menu__option" href="/signals/food/">Food, animals &amp; planet</a>
+          <a class="subject-menu__option" href="/signals/healthspan/">Healthspan &amp; care</a>
+          <a class="subject-menu__option" href="/signals/ai-work/">Work, education &amp; human capability</a>
+          <a class="subject-menu__option" href="/signals/financial-fragility/">Prosperity &amp; financial security</a>
+          <span class="subject-menu__option subject-menu__option--planned">Energy, compute &amp; infrastructure <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/demography/">Demography, migration &amp; aging</a>
+          <span class="subject-menu__option subject-menu__option--planned">Democracy, trust &amp; information <span class="subject-menu__badge">Planned</span></span>
+          <a class="subject-menu__option" href="/signals/science/" aria-current="location">Science, discovery &amp; AI systems</a>
+          <span class="subject-menu__option subject-menu__option--planned">Global resilience <span class="subject-menu__badge">Planned</span></span>
         </nav>
         <div class="evidence-hero-grid">
           <div>

--- a/ctw.studio/signals/signals.css
+++ b/ctw.studio/signals/signals.css
@@ -62,28 +62,8 @@ button { font: inherit; }
 }
 
 .topic-switcher {
-  position: relative;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.65rem;
-  overflow-x: visible;
   margin-bottom: clamp(3rem, 7vw, 6rem);
-  color: var(--muted);
-  font-family: var(--mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
-.signals-home,
-.topic-pill { flex: 0 0 auto; }
-.signals-home { color: var(--ink); font-weight: 500; text-decoration: none; }
-.signals-home:hover,
-.signals-home:focus-visible { color: var(--amber); }
-.topic-switcher__label { margin-right: 0.7rem; color: var(--ink); font-weight: 500; }
-.topic-pill { padding: 0.42rem 0.75rem; border: 1px solid var(--line); border-radius: 999px; text-decoration: none; }
-.topic-pill--active { border-color: rgba(247,181,0,0.45); background: rgba(247,181,0,0.09); color: var(--amber); }
-.topic-pill--future span { margin-left: 0.35rem; color: var(--ink-soft); }
 
 .hero-grid { position: relative; display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(350px, 0.65fr); gap: clamp(3rem, 8vw, 8rem); align-items: end; }
 .eyebrow {
@@ -163,18 +143,7 @@ button { font: inherit; }
 .evidence-page .signal-shell { width: min(1200px, calc(100% - 3rem)); }
 .evidence-hero { padding: 8rem 0 4rem; border-bottom: 1px solid var(--line); }
 .evidence-topics {
-  display: flex;
-  flex-wrap: wrap;
-  gap: .45rem;
-  align-items: center;
-  overflow-x: visible;
   padding-bottom: 4rem;
-}
-.evidence-topics .topic-pill { flex: 0 0 auto; font-size: .66rem; }
-.evidence-topics .topic-pill--active {
-  border-color: rgba(var(--topic-rgb), .5);
-  background: rgba(var(--topic-rgb), .11);
-  color: var(--topic);
 }
 .evidence-hero-grid {
   display: grid;
@@ -380,13 +349,6 @@ button { font: inherit; }
   .evidence-page .signal-shell,
   .evidence-layout { width: min(100% - 2rem, 1200px); }
   .evidence-hero { padding-top: 6.5rem; }
-  .evidence-topics {
-    flex-wrap: wrap;
-    overflow-x: visible;
-    margin-inline: 0;
-    padding-inline: 0;
-  }
-  .evidence-topics .topic-switcher__label { width: auto; }
   .evidence-hero h1 { font-size: clamp(2.75rem, 15vw, 4.4rem); }
   .lens-grid,
   .dimension-grid,
@@ -657,9 +619,7 @@ button { font: inherit; }
 @media (max-width: 760px) {
   .signal-shell { width: min(100% - 2rem, 1480px); }
   .signal-hero { padding-top: 7.2rem; }
-  .topic-switcher { align-items: center; margin-bottom: 3.5rem; }
-  .topic-switcher__label { width: auto; margin-bottom: 0; }
-  .topic-pill--future { display: none; }
+  .topic-switcher { margin-bottom: 3.5rem; }
   .hero-copy h1 { font-size: clamp(3rem, 15vw, 5.5rem); }
   .hero-question-row { grid-template-columns: 1fr 1fr; }
   .hero-question-row span { padding-left: .7rem; border-bottom: 1px solid var(--line); }

--- a/ctw.studio/signals/subject-menu.css
+++ b/ctw.studio/signals/subject-menu.css
@@ -1,3 +1,77 @@
+.subject-menu {
+  --subject-menu-surface: #0b0c0a;
+  --subject-menu-text: #f4f1e8;
+  --subject-menu-muted: #a4a49d;
+  --subject-menu-border: rgba(255, 255, 255, 0.36);
+  --subject-menu-accent: #f7b500;
+  --subject-menu-accent-soft: rgba(247, 181, 0, 0.11);
+  --subject-menu-font: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  color: var(--subject-menu-muted);
+  font: 500 0.72rem/1.3 var(--subject-menu-font);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.subject-menu .subject-menu__brand {
+  flex: 0 0 auto;
+  margin-right: 0.05rem;
+  color: var(--subject-menu-text);
+  letter-spacing: 0.1em;
+  text-decoration: none;
+}
+
+.subject-menu .subject-menu__option {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.42rem 0.75rem;
+  border: 1px solid var(--subject-menu-border);
+  border-radius: 999px;
+  color: var(--subject-menu-muted);
+  text-decoration: none;
+}
+
+.subject-menu__brand:hover,
+.subject-menu__brand:focus-visible,
+.subject-menu__option:hover,
+.subject-menu__option:focus-visible {
+  border-color: var(--subject-menu-border);
+  color: var(--subject-menu-text);
+}
+
+.subject-menu__brand:focus-visible,
+.subject-menu__option:focus-visible {
+  outline: 3px solid var(--subject-menu-accent);
+  outline-offset: 2px;
+}
+
+.subject-menu__option[aria-current="location"] {
+  border-color: var(--subject-menu-accent);
+  background: var(--subject-menu-accent-soft);
+  color: var(--subject-menu-accent);
+  box-shadow: inset 0 0 0 1px var(--subject-menu-accent);
+}
+
+.subject-menu__option--planned {
+  border-style: dashed;
+  color: var(--subject-menu-muted);
+  cursor: default;
+  pointer-events: none;
+}
+
+.subject-menu__badge {
+  color: var(--subject-menu-muted);
+  font-size: 0.68em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
 .subject-menu__trigger {
   display: none;
 }
@@ -6,30 +80,38 @@
   display: contents;
 }
 
-.topic-pill--planned {
-  cursor: default;
-  opacity: 1;
-  pointer-events: none;
-}
-
 @media (max-width: 760px) {
+  html:not(.subject-menu-ready) .subject-menu {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 0.5rem;
+  }
+
+  html:not(.subject-menu-ready) .subject-menu .subject-menu__brand {
+    margin: 0 0 0.25rem;
+  }
+
+  html:not(.subject-menu-ready) .subject-menu .subject-menu__option {
+    min-width: 0;
+    min-height: 44px;
+    justify-content: space-between;
+    padding: 0.7rem 0.8rem;
+    font: 500 1rem/1.35 var(--subject-menu-font);
+    letter-spacing: normal;
+    text-transform: none;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+
   .subject-menu-ready .subject-menu {
-    --subject-menu-surface: #0b0c0a;
-    --subject-menu-text: #f4f1e8;
-    --subject-menu-border: rgba(255, 255, 255, 0.36);
-    --subject-menu-accent: #f7b500;
-    --subject-menu-accent-soft: rgba(247, 181, 0, 0.11);
-    --subject-menu-font: Inter, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     position: relative;
     display: grid;
     grid-template-columns: auto minmax(0, 1fr);
     align-items: center;
     gap: 0.75rem;
-    margin-bottom: 3.5rem;
-    padding-bottom: 0;
   }
 
-  .subject-menu-ready .subject-menu .signals-home {
+  .subject-menu-ready .subject-menu__brand {
     width: auto;
     margin: 0;
   }
@@ -99,7 +181,7 @@
     display: grid;
   }
 
-  .subject-menu-ready .subject-menu__panel > :is(a, .topic-pill--planned) {
+  .subject-menu-ready .subject-menu__panel > .subject-menu__option {
     display: flex;
     min-width: 0;
     min-height: 44px;
@@ -118,12 +200,12 @@
     overflow-wrap: anywhere;
   }
 
-  .subject-menu-ready .subject-menu__panel > .topic-pill--planned {
+  .subject-menu-ready .subject-menu__panel > .subject-menu__option--planned {
     color: color-mix(in srgb, var(--subject-menu-text) 65%, transparent);
     cursor: default;
   }
 
-  .subject-menu-ready .topic-pill__badge {
+  .subject-menu-ready .subject-menu__badge {
     flex: 0 0 auto;
     color: color-mix(in srgb, var(--subject-menu-text) 55%, transparent);
     font: 500 0.68rem/1 var(--subject-menu-font);
@@ -138,9 +220,9 @@
   }
 
   .subject-menu-ready .subject-menu__panel a[aria-current="location"] {
-    background: var(--subject-menu-accent-soft) !important;
-    border-color: var(--subject-menu-accent) !important;
-    color: var(--subject-menu-accent) !important;
+    background: var(--subject-menu-accent-soft);
+    border-color: var(--subject-menu-accent);
+    color: var(--subject-menu-accent);
     box-shadow: inset 0 0 0 1px var(--subject-menu-accent);
   }
 

--- a/ctw.studio/signals/subject-menu.js
+++ b/ctw.studio/signals/subject-menu.js
@@ -1,12 +1,16 @@
 (() => {
   const mobile = matchMedia('(max-width: 760px)');
 
-  document.querySelectorAll('.atlas-topics, .topic-switcher, .evidence-topics').forEach((nav, index) => {
-    const brand = nav.querySelector(':scope > .signals-home');
+  document.querySelectorAll('.subject-menu').forEach((nav, index) => {
+    if (nav.dataset.subjectMenuEnhanced === 'true') return;
+
+    const brand = nav.querySelector(':scope > .subject-menu__brand');
     const options = [...nav.children].filter((option) =>
-      option.matches('a:not(.signals-home), .topic-pill--planned')
+      option.matches('.subject-menu__option')
     );
     if (!brand || options.length !== 10) return;
+
+    nav.dataset.subjectMenuEnhanced = 'true';
 
     const current = options.find((option) => option.matches('a[aria-current="location"]'));
     const panel = document.createElement('div');
@@ -30,7 +34,6 @@
     icon.textContent = '▾';
     trigger.append(label, icon);
 
-    nav.classList.add('subject-menu');
     nav.append(trigger, panel);
 
     const sizePanel = () => {

--- a/ctw.studio/signals/tests/food.test.mjs
+++ b/ctw.studio/signals/tests/food.test.mjs
@@ -87,7 +87,7 @@ test('food page exposes the complete storyboard, chart alternatives, and active 
   }
   assert.match(html, /href="\/signals\/">Signals \//);
   assert.match(html, /href="\/signals\/food\/"[^>]*aria-current="location"/);
-  assert.match(html, /food-active/);
+  assert.match(html, /<a class="subject-menu__option" href="\/signals\/food\/" aria-current="location">/);
   assert.match(html, /species-table/);
   assert.match(html, /footprint-table/);
   assert.match(html, /Scenario, not forecast/);

--- a/ctw.studio/signals/tests/roadmap.test.mjs
+++ b/ctw.studio/signals/tests/roadmap.test.mjs
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { readFile, readdir } from 'node:fs/promises';
 
 const root = new URL('../', import.meta.url);
 const html = await readFile(new URL('index.html', root), 'utf8');
@@ -9,6 +9,12 @@ const vercel = JSON.parse(await readFile(new URL('../vercel.json', root), 'utf8'
 const atlasCss = await readFile(new URL('atlas.css', root), 'utf8');
 const subjectMenuCss = await readFile(new URL('subject-menu.css', root), 'utf8');
 const subjectMenuJs = await readFile(new URL('subject-menu.js', root), 'utf8');
+const pageCssFiles = (await readdir(root, { recursive: true }))
+  .filter((file) => file.endsWith('.css') && file !== 'subject-menu.css');
+const pageCss = await Promise.all(pageCssFiles.map(async (file) => ({
+  file,
+  css: await readFile(new URL(file, root), 'utf8')
+})));
 
 const subjects = [
   { label: 'Housing &amp; affordability', anchor: 'subject-housing-affordability', route: '/signals/housing/', status: 'published', briefs: [['housing', '003']] },
@@ -34,14 +40,35 @@ const briefPages = await Promise.all(briefs.map(async (brief) => ({
 
 const expectedLabels = subjects.map(({ label }) => label);
 const expectedRoutes = subjects.map(({ route }) => route);
+const placementClasses = new Map([
+  ['atlas', 'atlas-topics'],
+  ['ai-work', 'topic-switcher'],
+  ['food', 'topic-switcher'],
+  ['housing', 'housing-topics'],
+  ['science', 'evidence-topics'],
+  ['healthspan', 'evidence-topics'],
+  ['real-time-ai', 'evidence-topics'],
+  ['demography', 'evidence-topics'],
+  ['education', 'evidence-topics'],
+  ['financial-fragility', 'fragility-topics']
+]);
+const legacyNavClasses = [
+  'topic-pill',
+  'topic-pill--active',
+  'atlas-brand',
+  'topic-switcher__label',
+  'food-active',
+  'active',
+  'housing-active',
+  'fragility-active'
+];
 
 function subjectOptions(markup) {
   const options = [];
-  const pattern = /<a(?: class="([^"]*)")? href="([^"]+)"(?: aria-current="([^"]+)")?>([^<]+)<\/a>|<span class="([^"]*\btopic-pill--planned\b[^"]*)">([^<]+) <span class="topic-pill__badge">Planned<\/span><\/span>/g;
+  const pattern = /<a class="([^"]*\bsubject-menu__option\b[^"]*)" href="([^"]+)"(?: aria-current="([^"]+)")?>([^<]+)<\/a>|<span class="([^"]*\bsubject-menu__option--planned\b[^"]*)">([^<]+) <span class="subject-menu__badge">Planned<\/span><\/span>/g;
 
   for (const match of markup.matchAll(pattern)) {
     const [, classes = '', href, current, linkLabel, plannedClasses, plannedLabel] = match;
-    if (classes.split(/\s+/).includes('signals-home')) continue;
     options.push({
       classes: href ? classes : plannedClasses,
       current,
@@ -52,6 +79,30 @@ function subjectOptions(markup) {
     });
   }
   return options;
+}
+
+function subjectNav(markup) {
+  return markup.match(/<nav class="[^"]*\bsubject-menu\b[^"]*"[\s\S]*?<\/nav>/)?.[0] || '';
+}
+
+function assertStaticContract(route, markup) {
+  const nav = subjectNav(markup);
+  assert.ok(nav, `${route} missing subject menu`);
+
+  const navClasses = nav.match(/^<nav class="([^"]+)"/)?.[1].split(/\s+/) || [];
+  assert.deepEqual(navClasses, ['subject-menu', placementClasses.get(route)], `${route} has wrong nav classes`);
+  assert.match(nav, /<a class="subject-menu__brand" href="\/signals\/">Signals \/<\/a>/);
+  for (const legacyClass of legacyNavClasses) {
+    assert.doesNotMatch(nav, new RegExp(`class="[^"]*\\b${legacyClass}\\b`), `${route} retains ${legacyClass}`);
+  }
+
+  const options = subjectOptions(nav);
+  assert.deepEqual(options.map(({ label }) => label), expectedLabels, `${route} subject order differs`);
+  assert.deepEqual(options.map(({ route: optionRoute }) => optionRoute), expectedRoutes, `${route} subject routes differ`);
+  assert.equal(options.length, 10, `${route} must have ten options`);
+  assert.equal(options.filter(({ tag }) => tag === 'a').length, 7, `${route} must have seven subject links`);
+  assert.equal(options.filter(({ tag }) => tag === 'span').length, 3, `${route} must have three planned rows`);
+  return { nav, options };
 }
 
 function cssRule(selector) {
@@ -98,32 +149,15 @@ test('Atlas counters and subject wording report 9 briefs, 7 covered subjects and
 });
 
 test('Atlas top navigation uses exact canonical routes and native planned rows', () => {
-  const nav = html.match(/<nav class="atlas-topics"[\s\S]*?<\/nav>/)?.[0] || '';
-  assert.match(nav, /<a class="signals-home atlas-brand" href="\/signals\/">Signals \/<\/a>/);
-  const options = subjectOptions(nav);
-  assert.deepEqual(options.map(({ label }) => label), expectedLabels);
-  assert.deepEqual(options.map(({ route }) => route), expectedRoutes);
-  assert.equal(options.filter(({ tag }) => tag === 'a').length, 7);
-  assert.equal(options.filter(({ tag }) => tag === 'span').length, 3);
+  const { nav, options } = assertStaticContract('atlas', html);
   assert.equal(options.filter(({ current }) => current).length, 0);
   assert.doesNotMatch(nav, />Atlas<\/a>/);
 });
 
 test('every brief switcher mirrors exact routes, planned rows and mapped current subject', () => {
   briefPages.forEach(({ route, subjectRoute, briefId, html: page }) => {
-    const nav = page.match(/<nav class="[^"]*(?:topic-switcher|evidence-topics)[^"]*"[\s\S]*?<\/nav>/)?.[0] || '';
-    assert.ok(nav, `${route} missing semantic topic navigation`);
-    assert.match(nav, /<a class="signals-home topic-switcher__label" href="\/signals\/">/);
-
-    const options = subjectOptions(nav);
-    assert.deepEqual(options.map(({ label }) => label), expectedLabels, `${route} subject order differs`);
-    assert.deepEqual(options.map(({ route }) => route), expectedRoutes, `${route} subject routes differ`);
-    assert.equal(options.filter(({ tag }) => tag === 'a').length, 7, `${route} must have seven subject links`);
-    assert.equal(options.filter(({ tag }) => tag === 'span').length, 3, `${route} must have three planned rows`);
-
-    const current = options.filter(({ classes, current }) =>
-      classes.split(/\s+/).includes('topic-pill--active') || current
-    );
+    const { options } = assertStaticContract(route, page);
+    const current = options.filter(({ current }) => current);
     assert.equal(current.length, 1, `${route} must have one mapped current subject`);
     assert.equal(current[0].tag, 'a', `${route} current subject must be a link`);
     assert.equal(current[0].route, subjectRoute, `${route} maps to wrong subject`);
@@ -134,17 +168,17 @@ test('every brief switcher mirrors exact routes, planned rows and mapped current
 
 test('planned subject rows stay visibly native and noninteractive on every navigation copy', () => {
   for (const { route, html: page } of [{ route: 'atlas', html }, ...briefPages]) {
-    const nav = page.match(/<nav class="[^"]*(?:atlas-topics|topic-switcher|evidence-topics)[^"]*"[\s\S]*?<\/nav>/)?.[0] || '';
+    const nav = subjectNav(page);
     const planned = subjectOptions(nav).filter(({ tag }) => tag === 'span');
 
     assert.equal(planned.length, 3, `${route} planned-row count differs`);
     for (const option of planned) {
-      assert.match(option.markup, /<span class="topic-pill__badge">Planned<\/span>/);
+      assert.match(option.markup, /<span class="subject-menu__badge">Planned<\/span>/);
       assert.doesNotMatch(option.markup, /\b(?:href|role|tabindex|onclick|aria-disabled)=/i);
     }
   }
-  assert.match(atlasCss, /\.atlas-topics \.topic-pill--planned\s*\{[^}]*color:\s*var\(--atlas-muted\)/s);
-  assert.match(atlasCss, /\.atlas-topics \.topic-pill__badge\s*\{[^}]*color:\s*var\(--atlas-muted\)/s);
+  assert.match(cssRule('.subject-menu__option--planned'), /pointer-events:\s*none/);
+  assert.match(cssRule('.subject-menu__option--planned'), /cursor:\s*default/);
 });
 
 test('all taxonomy pages load shared progressive subject disclosure assets', () => {
@@ -160,13 +194,24 @@ test('all taxonomy pages load shared progressive subject disclosure assets', () 
 
   assert.match(subjectMenuCss, /@media \(max-width: 760px\)/);
   assert.match(subjectMenuCss, /\.subject-menu__panel\[aria-hidden="false"\]/);
-  assert.match(cssRule('.subject-menu-ready .subject-menu'), /--subject-menu-border:\s*rgba\(255, 255, 255, 0\.36\)/);
-  assert.match(cssRule('.subject-menu-ready .subject-menu'), /--subject-menu-accent:\s*#f7b500/);
-  assert.match(cssRule('.subject-menu-ready .subject-menu'), /--subject-menu-font:\s*Inter,\s*system-ui,\s*-apple-system,\s*BlinkMacSystemFont,\s*"Segoe UI",\s*sans-serif/);
+  assert.match(cssRule('.subject-menu'), /--subject-menu-border:\s*rgba\(255, 255, 255, 0\.36\)/);
+  assert.match(cssRule('.subject-menu'), /--subject-menu-accent:\s*#f7b500/);
+  assert.match(cssRule('.subject-menu'), /--subject-menu-font:\s*Inter,\s*system-ui,\s*-apple-system,\s*BlinkMacSystemFont,\s*"Segoe UI",\s*sans-serif/);
+  assert.match(cssRule('.subject-menu'), /display:\s*flex/);
+  assert.match(cssRule('.subject-menu'), /flex-wrap:\s*wrap/);
+  assert.match(cssRule('.subject-menu'), /align-items:\s*center/);
+  assert.match(cssRule('.subject-menu'), /gap:\s*0\.65rem/);
+  assert.match(cssRule('.subject-menu .subject-menu__option'), /padding:\s*0\.42rem 0\.75rem/);
+  assert.match(cssRule('.subject-menu .subject-menu__option'), /border-radius:\s*999px/);
+  assert.match(cssRule('html:not(.subject-menu-ready) .subject-menu'), /grid-template-columns:\s*minmax\(0, 1fr\)/);
+  assert.match(cssRule('html:not(.subject-menu-ready) .subject-menu .subject-menu__option'), /min-height:\s*44px/);
+  assert.match(cssRule('html:not(.subject-menu-ready) .subject-menu .subject-menu__option'), /overflow-wrap:\s*anywhere/);
+  assert.match(cssRule('.subject-menu__badge'), /white-space:\s*nowrap/);
+  assert.match(cssRule('.subject-menu__option[aria-current="location"]'), /color:\s*var\(--subject-menu-accent\)/);
   for (const selector of [
     '.subject-menu-ready .subject-menu__trigger',
     '.subject-menu-ready .subject-menu__panel',
-    '.subject-menu-ready .subject-menu__panel > :is(a, .topic-pill--planned)'
+    '.subject-menu-ready .subject-menu__panel > .subject-menu__option'
   ]) {
     const rule = cssRule(selector);
     assert.match(rule, /font:\s*500 1rem\/1\.35 var\(--subject-menu-font\)/);
@@ -177,9 +222,9 @@ test('all taxonomy pages load shared progressive subject disclosure assets', () 
     assert.doesNotMatch(rule, /(?:font|color):\s*inherit/);
   }
   const currentRule = cssRule('.subject-menu-ready .subject-menu__panel a[aria-current="location"]');
-  assert.match(currentRule, /background:\s*var\(--subject-menu-accent-soft\)\s*!important/);
-  assert.match(currentRule, /border-color:\s*var\(--subject-menu-accent\)\s*!important/);
-  assert.match(currentRule, /color:\s*var\(--subject-menu-accent\)\s*!important/);
+  assert.match(currentRule, /background:\s*var\(--subject-menu-accent-soft\)/);
+  assert.match(currentRule, /border-color:\s*var\(--subject-menu-accent\)/);
+  assert.match(currentRule, /color:\s*var\(--subject-menu-accent\)/);
   assert.match(currentRule, /box-shadow:\s*inset [^;]*var\(--subject-menu-accent\)/);
   const focusRule = cssRule('.subject-menu-ready .subject-menu__panel a:focus-visible');
   assert.match(focusRule, /border-color:\s*var\(--subject-menu-accent\)/);
@@ -189,21 +234,40 @@ test('all taxonomy pages load shared progressive subject disclosure assets', () 
   assert.match(hoverRule, /background:\s*rgba\(255, 255, 255, 0\.07\)/);
   assert.match(hoverRule, /border-color:\s*var\(--subject-menu-border\)/);
   assert.match(hoverRule, /color:\s*var\(--subject-menu-text\)/);
-  const plannedRule = cssRule('.subject-menu-ready .subject-menu__panel > .topic-pill--planned');
+  const plannedRule = cssRule('.subject-menu-ready .subject-menu__panel > .subject-menu__option--planned');
   assert.match(plannedRule, /color:\s*color-mix\(in srgb, var\(--subject-menu-text\) 65%, transparent\)/);
   assert.match(plannedRule, /cursor:\s*default/);
-  assert.match(cssRule('.topic-pill--planned'), /opacity:\s*1/);
-  assert.match(cssRule('.topic-pill--planned'), /pointer-events:\s*none/);
+  assert.match(cssRule('.subject-menu__option--planned'), /pointer-events:\s*none/);
+  assert.doesNotMatch(subjectMenuCss, /!important/);
   assert.match(subjectMenuJs, /createElement\('button'\)/);
   assert.match(subjectMenuJs, /setAttribute\('aria-expanded'/);
   assert.match(subjectMenuJs, /setAttribute\('aria-controls'/);
-  assert.match(subjectMenuJs, /option\.matches\('a:not\(\.signals-home\), \.topic-pill--planned'\)/);
+  assert.match(subjectMenuJs, /querySelectorAll\('\.subject-menu'\)/);
+  assert.match(subjectMenuJs, /subjectMenuEnhanced === 'true'/);
+  assert.match(subjectMenuJs, /subjectMenuEnhanced = 'true'/);
+  assert.match(subjectMenuJs, /option\.matches\('\.subject-menu__option'\)/);
   assert.match(subjectMenuJs, /options\.length !== 10/);
   assert.match(subjectMenuJs, /option\.matches\('a\[aria-current="location"\]'\)/);
   assert.match(subjectMenuJs, /options\.forEach\(\(option\) => panel\.append\(option\)\)/);
   assert.match(subjectMenuJs, /\|\| 'Explore subjects'/);
   assert.match(subjectMenuJs, /event\.target\.closest\('a'\)/);
   assert.match(subjectMenuJs, /event\.key === 'Escape'/);
+});
+
+test('subject menu CSS owns internals while page styles retain placement only', () => {
+  for (const { file, css } of pageCss) {
+    assert.doesNotMatch(
+      css,
+      /subject-menu__|topic-pill|atlas-brand|topic-switcher__label|food-active|housing-active|fragility-active|\.signals-home/,
+      `${file} owns subject-menu internals`
+    );
+  }
+
+  assert.match(atlasCss, /\.atlas-topics\s*\{\s*padding-bottom:\s*78px;\s*\}/);
+  assert.match(pageCss.find(({ file }) => file === 'signals.css').css, /\.topic-switcher\s*\{\s*margin-bottom:\s*clamp\(3rem, 7vw, 6rem\);\s*\}/);
+  assert.match(pageCss.find(({ file }) => file === 'signals.css').css, /\.evidence-topics\s*\{\s*padding-bottom:\s*4rem;\s*\}/);
+  assert.match(pageCss.find(({ file }) => file === 'housing/housing.css').css, /\.housing-topics\s*\{\s*padding:\s*3px 0 52px;\s*\}/);
+  assert.match(pageCss.find(({ file }) => file === 'financial-fragility/financial-fragility.css').css, /\.fragility-topics\s*\{\s*padding:\s*118px 0 24px;\s*\}/);
 });
 
 test('first wave uses canonical vocabulary and truthful coverage state', () => {


### PR DESCRIPTION
## Summary
- normalize all ten Signals navigations to one static component contract
- centralize desktop, mobile, and no-JS styling in `subject-menu.css`
- remove page-theme menu leakage while preserving outer hero placement
- keep seven direct subject routes, three Planned rows, and current mappings
- keep CTW Studio static; no SvelteKit or deployment changes

## Verification
- `node --test signals/tests/*.test.mjs` — 105/105 passed
- canonical JS syntax checks — passed
- Python updater syntax checks — passed
- real Chrome audit across all ten desktop and mobile pages — passed
- no-JS desktop/mobile audit across all ten pages — passed
- direct route navigation and keyboard interactions — passed
- fresh independent review — clean
- `git diff --check` — passed

Closes #151